### PR TITLE
Multi-GPU support + random/lottery search mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cyclone_tests_results.txt
 
 # Windows
 Thumbs.db
+nul

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Build artifacts
+*.o
+*.obj
+*.exe
+CUDACyclone
+CUDACyclone.exe
+
+# Test results
+cyclone_tests_results.txt
+
+# Windows
+Thumbs.db

--- a/CUDACyclone.cu
+++ b/CUDACyclone.cu
@@ -38,7 +38,7 @@ __device__ __forceinline__ bool warp_found_ready(const int* __restrict__ d_found
 }
 
 #ifndef MAX_BATCH_SIZE
-#define MAX_BATCH_SIZE 1024
+#define MAX_BATCH_SIZE 1536
 #endif
 #ifndef WARP_SIZE
 #define WARP_SIZE 32
@@ -468,47 +468,17 @@ int main(int argc, char** argv) {
         }
     }
 
-    auto is_pow2 = [](uint32_t v)->bool { return v && ((v & (v-1)) == 0); };
-    if (!is_pow2(runtime_points_batch_size) || (runtime_points_batch_size & 1u)) {
-        std::cerr << "Error: batch size must be even and a power of two.\n";
+    if (runtime_points_batch_size < 2 || (runtime_points_batch_size & 1u)) {
+        std::cerr << "Error: batch size must be at least 2 and even.\n";
         return EXIT_FAILURE;
     }
     if (runtime_points_batch_size > MAX_BATCH_SIZE) {
-        std::cerr << "Error: batch size must be <= " << MAX_BATCH_SIZE << " (kernel limit).\n";
+        std::cerr << "Error: batch size must be <= " << MAX_BATCH_SIZE << " (constant memory limit).\n";
         return EXIT_FAILURE;
     }
 
     uint64_t range_len[4]; sub256(range_end, range_start, range_len); add256_u64(range_len, 1ull, range_len);
-
-    auto is_zero_256 = [](const uint64_t a[4])->bool { return (a[0]|a[1]|a[2]|a[3]) == 0ull; };
-    auto is_power_of_two_256 = [&](const uint64_t a[4])->bool {
-        if (is_zero_256(a)) return false;
-        uint64_t am1[4]; uint64_t borrow = 1ull;
-        for (int i=0;i<4;++i) {
-            uint64_t v = a[i] - borrow; borrow = (a[i] < borrow) ? 1ull : 0ull; am1[i] = v;
-            if (!borrow && i+1<4) { for (int k=i+1;k<4;++k) am1[k] = a[k]; break; }
-        }
-        uint64_t and0=a[0]&am1[0], and1=a[1]&am1[1], and2=a[2]&am1[2], and3=a[3]&am1[3];
-        return (and0|and1|and2|and3)==0ull;
-    };
-    if (!is_power_of_two_256(range_len)) {
-        std::cerr << "Error: range length (end - start + 1) must be a power of two.\n"; return EXIT_FAILURE;
-    }
-    uint64_t len_minus1[4];
-    {   uint64_t borrow=1ull;
-        for (int i=0;i<4;++i) {
-            uint64_t v=range_len[i]-borrow; borrow=(range_len[i]<borrow)?1ull:0ull; len_minus1[i]=v;
-            if (!borrow && i+1<4) { for (int k=i+1;k<4;++k) len_minus1[k]=range_len[k]; break; }
-        }
-    }
-    {   uint64_t and0 = range_start[0] & len_minus1[0];
-        uint64_t and1 = range_start[1] & len_minus1[1];
-        uint64_t and2 = range_start[2] & len_minus1[2];
-        uint64_t and3 = range_start[3] & len_minus1[3];
-        if ((and0|and1|and2|and3) != 0ull) {
-            std::cerr << "Error: start must be aligned to the range length.\n"; return EXIT_FAILURE;
-        }
-    }
+    uint64_t q_div_batch[4];
 
     int device=0; cudaDeviceProp prop{};
     if (cudaGetDevice(&device)!=cudaSuccess || cudaGetDeviceProperties(&prop, device)!=cudaSuccess) {
@@ -527,48 +497,42 @@ int main(int argc, char** argv) {
     uint64_t usableMem = (totalGlobalMem > reserveBytes) ? (totalGlobalMem - reserveBytes) : (totalGlobalMem / 2);
     uint64_t maxThreadsByMem = usableMem / bytesPerThread;
 
-    uint64_t q_div_batch[4], r_div_batch = 0ull;
-    divmod_256_by_u64(range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_div_batch);
-    if (r_div_batch != 0ull) {
-        std::cerr << "Error: range length must be divisible by batch size (" << runtime_points_batch_size << ").\n";
-        return EXIT_FAILURE;
+    // Round range_len up to nearest multiple of batch_size
+    uint64_t r_batch = 0ull;
+    divmod_256_by_u64(range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
+    if (r_batch != 0ull) {
+        uint64_t adjust = (uint64_t)runtime_points_batch_size - r_batch;
+        add256_u64(range_len, adjust, range_len);
+        divmod_256_by_u64(range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
     }
     bool q_fits_u64 = (q_div_batch[3]|q_div_batch[2]|q_div_batch[1]) == 0ull;
-    uint64_t total_batches_u64 = q_fits_u64 ? q_div_batch[0] : 0ull;
-    if (!q_fits_u64) { std::cerr << "Error: total batches too large for u64.\n"; return EXIT_FAILURE; }
+    if (!q_fits_u64) { std::cerr << "Error: range too large.\n"; return EXIT_FAILURE; }
+    uint64_t total_batches_u64 = q_div_batch[0];
 
     uint64_t userUpper = (uint64_t)prop.multiProcessorCount * (uint64_t)runtime_batches_per_sm * (uint64_t)threadsPerBlock;
     if (userUpper == 0ull) userUpper = UINT64_MAX;
 
-    auto pick_threads_total = [&](uint64_t upper)->uint64_t {
-        if (upper < (uint64_t)threadsPerBlock) return 0ull;
-        uint64_t t = upper - (upper % (uint64_t)threadsPerBlock);
-        uint64_t q = total_batches_u64;
-        while (t >= (uint64_t)threadsPerBlock) {
-            if ((q % t) == 0ull) return t;
-            t -= (uint64_t)threadsPerBlock;
-        }
-        return 0ull;
-    };
-
-    uint64_t upper = maxThreadsByMem;
-    if (total_batches_u64 < upper) upper = total_batches_u64;
-    if (userUpper         < upper) upper = userUpper;
-
-    uint64_t threadsTotal = pick_threads_total(upper);
-    if (threadsTotal == 0ull) {
-        std::cerr << "Error: failed to pick threadsTotal satisfying divisibility.\n";
-        return EXIT_FAILURE;
+    // Pick threadsTotal: pick the max possible, then adjust total_batches to match
+    uint64_t desired_upper = maxThreadsByMem;
+    if (userUpper < desired_upper) desired_upper = userUpper;
+    uint64_t threadsTotal = (desired_upper / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
+    if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
+    if (total_batches_u64 < threadsTotal) {
+        threadsTotal = (total_batches_u64 / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
+        if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
     }
+    // Adjust total_batches to be divisible by threadsTotal
+    if ((total_batches_u64 % threadsTotal) != 0ull) {
+        uint64_t rem = total_batches_u64 % threadsTotal;
+        total_batches_u64 += threadsTotal - rem;
+        uint64_t add_keys = (threadsTotal - rem) * (uint64_t)runtime_points_batch_size;
+        add256_u64(range_len, add_keys, range_len);
+    }
+
     int blocks = (int)(threadsTotal / (uint64_t)threadsPerBlock);
 
     uint64_t per_thread_cnt[4]; uint64_t r_u64 = 0ull;
     divmod_256_by_u64(range_len, threadsTotal, per_thread_cnt, r_u64);
-    if (r_u64 != 0ull) { std::cerr << "Internal error: range_len not divisible by threadsTotal.\n"; return EXIT_FAILURE; }
-    {   uint64_t qq[4], rr=0ull;
-        divmod_256_by_u64(per_thread_cnt, (uint64_t)runtime_points_batch_size, qq, rr);
-        if (rr != 0ull) { std::cerr << "Internal error: per-thread count is not a multiple of batch size.\n"; return EXIT_FAILURE; }
-    }
 
     uint64_t* h_counts256     = nullptr;
     uint64_t* h_start_scalars = nullptr;
@@ -760,10 +724,19 @@ int main(int argc, char** argv) {
                 long double total_keys_ld = ld_from_u256(range_len);
                 long double prog = total_keys_ld > 0.0L ? ((long double)h_hashes / total_keys_ld) * 100.0L : 0.0L;
                 if (prog > 100.0L) prog = 100.0L;
-                std::cout << "\rTime: " << std::fixed << std::setprecision(1) << elapsed
-                          << " s | Speed: " << std::fixed << std::setprecision(1) << mkeys
-                          << " Mkeys/s | Count: " << h_hashes
-                          << " | Progress: " << std::fixed << std::setprecision(2) << (double)prog << " %";
+                double speed_val = mkeys;
+                const char* speed_unit = "Mkeys/s";
+                if (speed_val >= 1000000.0) {
+                    speed_val /= 1000000.0;
+                    speed_unit = "Tkeys/s";
+                } else if (speed_val >= 1000.0) {
+                    speed_val /= 1000.0;
+                    speed_unit = "Gkeys/s";
+                }
+                std::cout << "\rTime: " << std::fixed << std::setprecision(1) << std::setw(6) << elapsed
+                          << " s | Speed: " << std::fixed << std::setprecision(2) << std::setw(7) << speed_val
+                          << " " << speed_unit << " | Count: " << std::setw(14) << h_hashes
+                          << " | Progress: " << std::fixed << std::setprecision(2) << std::setw(6) << (double)prog << " %   ";
                 std::cout.flush();
                 lastHashes = h_hashes; tLast = now;
             }

--- a/CUDACyclone.cu
+++ b/CUDACyclone.cu
@@ -14,6 +14,10 @@
 #include <cmath>
 #include <csignal>
 #include <atomic>
+#include <mutex>
+#include <vector>
+#include <array>
+#include <random>
 
 #include "CUDAMath.h"
 #include "sha256.h"
@@ -94,7 +98,7 @@ __global__ void kernel_point_add_and_check_oneinv(
         const uint64_t idx = gid * 4 + i;
         x1[i] = Px[idx];
         y1[i] = Py[idx];
-        S[i]  = start_scalars[idx];   
+        S[i]  = start_scalars[idx];
     }
     uint64_t rem[4];
 #pragma unroll
@@ -184,11 +188,11 @@ __global__ void kernel_point_add_and_check_oneinv(
                 ModSub256(s, py_i, y1);
                 _ModMult(lam, s, dx_inv_i);
 
-                _ModSqr(px3, lam);     
+                _ModSqr(px3, lam);
                 ModSub256(px3, px3, x1);
                 ModSub256(px3, px3, px_i);
 
-                ModSub256(s, x1, px3); 
+                ModSub256(s, x1, px3);
                 _ModMult(s, s, lam);
                 uint8_t odd; ModSub256isOdd(s, y1, &odd);
 
@@ -206,7 +210,7 @@ __global__ void kernel_point_add_and_check_oneinv(
                             for (int k=0;k<4;++k) d_found_result->scalar[k]=fs[k];
 #pragma unroll
                             for (int k=0;k<4;++k) d_found_result->Rx[k]=px3[k];
-                           
+
                             uint64_t y3[4]; uint64_t t[4]; ModSub256(t, x1, px3); _ModMult(y3, t, lam); ModSub256(y3, y3, y1);
 #pragma unroll
                             for (int k=0;k<4;++k) d_found_result->Ry[k]=y3[k];
@@ -225,7 +229,7 @@ __global__ void kernel_point_add_and_check_oneinv(
                 uint64_t px_i[4], py_i[4];
 #pragma unroll
                 for (int j=0;j<4;++j) { px_i[j]=c_Gx[(size_t)i*4+j]; py_i[j]=c_Gy[(size_t)i*4+j]; }
-                ModNeg256(py_i, py_i); 
+                ModNeg256(py_i, py_i);
 
                 ModSub256(s, py_i, y1);
                 _ModMult(lam, s, dx_inv_i);
@@ -382,6 +386,436 @@ extern bool decode_p2pkh_address(const std::string& addr, uint8_t out20[20]);
 extern std::string formatCompressedPubHex(const uint64_t X[4], const uint64_t Y[4]);
 __global__ void scalarMulKernelBase(const uint64_t* scalars_in, uint64_t* outX, uint64_t* outY, int N);
 
+// ── Shared state between GPU threads ──────────────────────────────────────────
+struct GpuShared {
+    std::atomic<int>                any_found{0};
+    std::mutex                      result_mtx;
+    FoundResult                     best_result{};
+    bool                            has_result{false};
+    std::atomic<unsigned long long> total_hashes{0};
+    std::atomic<unsigned long long> chunks_tried{0};
+    std::atomic<int>                gpus_exhausted{0};
+    std::atomic<int>                init_done{0};
+};
+
+static std::mutex g_print_mutex;
+
+// ── Per-GPU worker ────────────────────────────────────────────────────────────
+static void run_on_gpu(
+    int            gpu_id,
+    const uint64_t range_start[4],
+    const uint64_t range_end[4],
+    const uint8_t  target_hash160[20],
+    uint32_t       runtime_points_batch_size,
+    uint32_t       runtime_batches_per_sm,
+    uint32_t       slices_per_launch,
+    bool           random_mode,
+    GpuShared&     shared
+) {
+    cudaSetDevice(gpu_id);
+    cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
+
+    auto ck = [&](cudaError_t e, const char* msg) {
+        if (e != cudaSuccess) {
+            std::lock_guard<std::mutex> lk(g_print_mutex);
+            fprintf(stderr, "\n[GPU %d] %s: %s\n", gpu_id, msg, cudaGetErrorString(e));
+            std::exit(EXIT_FAILURE);
+        }
+    };
+
+    cudaDeviceProp prop{};
+    ck(cudaGetDeviceProperties(&prop, gpu_id), "cudaGetDeviceProperties");
+
+    int threadsPerBlock = 256;
+    if (threadsPerBlock > (int)prop.maxThreadsPerBlock) threadsPerBlock = prop.maxThreadsPerBlock;
+    if (threadsPerBlock < 32) threadsPerBlock = 32;
+
+    uint64_t gpu_range_len[4];
+    sub256(range_end, range_start, gpu_range_len);
+    add256_u64(gpu_range_len, 1ull, gpu_range_len);
+
+    const uint64_t bytesPerThread = 2ull * 4ull * sizeof(uint64_t);
+    size_t totalGlobalMem = prop.totalGlobalMem;
+    const uint64_t reserveBytes = 64ull * 1024 * 1024;
+    uint64_t usableMem = (totalGlobalMem > reserveBytes) ? (totalGlobalMem - reserveBytes) : (totalGlobalMem / 2);
+    uint64_t maxThreadsByMem = usableMem / bytesPerThread;
+
+    uint64_t q_div_batch[4]; uint64_t r_batch = 0ull;
+    divmod_256_by_u64(gpu_range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
+    if (r_batch != 0ull) {
+        uint64_t adjust = (uint64_t)runtime_points_batch_size - r_batch;
+        add256_u64(gpu_range_len, adjust, gpu_range_len);
+        divmod_256_by_u64(gpu_range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
+    }
+    if ((q_div_batch[3] | q_div_batch[2] | q_div_batch[1]) != 0ull) {
+        std::lock_guard<std::mutex> lk(g_print_mutex);
+        fprintf(stderr, "[GPU %d] Error: range too large.\n", gpu_id);
+        std::exit(EXIT_FAILURE);
+    }
+    uint64_t total_batches_u64 = q_div_batch[0];
+
+    uint64_t userUpper = (uint64_t)prop.multiProcessorCount * (uint64_t)runtime_batches_per_sm * (uint64_t)threadsPerBlock;
+    if (userUpper == 0ull) userUpper = UINT64_MAX;
+
+    uint64_t desired_upper = maxThreadsByMem;
+    if (userUpper < desired_upper) desired_upper = userUpper;
+    uint64_t threadsTotal = (desired_upper / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
+    if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
+    if (total_batches_u64 < threadsTotal) {
+        threadsTotal = (total_batches_u64 / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
+        if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
+    }
+    if ((total_batches_u64 % threadsTotal) != 0ull) {
+        uint64_t rem = total_batches_u64 % threadsTotal;
+        total_batches_u64 += threadsTotal - rem;
+        add256_u64(gpu_range_len, (threadsTotal - rem) * (uint64_t)runtime_points_batch_size, gpu_range_len);
+    }
+
+    int blocks = (int)(threadsTotal / (uint64_t)threadsPerBlock);
+
+    uint64_t per_thread_cnt[4]; uint64_t r_u64 = 0ull;
+    if (random_mode) {
+        // Each kernel launch covers exactly one fixed-size chunk per thread
+        per_thread_cnt[0] = (uint64_t)runtime_points_batch_size * slices_per_launch;
+        per_thread_cnt[1] = per_thread_cnt[2] = per_thread_cnt[3] = 0ull;
+    } else {
+        divmod_256_by_u64(gpu_range_len, threadsTotal, per_thread_cnt, r_u64);
+    }
+
+    const uint32_t B    = runtime_points_batch_size;
+    const uint32_t half = B >> 1;
+
+    // Target constants (per-device constant memory)
+    {
+        uint32_t prefix_le = (uint32_t)target_hash160[0]
+                           | ((uint32_t)target_hash160[1] << 8)
+                           | ((uint32_t)target_hash160[2] << 16)
+                           | ((uint32_t)target_hash160[3] << 24);
+        ck(cudaMemcpyToSymbol(c_target_prefix,  &prefix_le,    sizeof(prefix_le)), "ToSymbol c_target_prefix");
+        ck(cudaMemcpyToSymbol(c_target_hash160, target_hash160, 20),               "ToSymbol c_target_hash160");
+    }
+
+    // Host buffers (plain malloc — no cudaHostAlloc needed for one-time upload)
+    std::vector<uint64_t> h_counts256(threadsTotal * 4);
+    std::vector<uint64_t> h_start_scalars(threadsTotal * 4);
+
+    for (uint64_t i = 0; i < threadsTotal; ++i) {
+        h_counts256[i*4+0] = per_thread_cnt[0];
+        h_counts256[i*4+1] = per_thread_cnt[1];
+        h_counts256[i*4+2] = per_thread_cnt[2];
+        h_counts256[i*4+3] = per_thread_cnt[3];
+    }
+    {
+        uint64_t cur[4] = { range_start[0], range_start[1], range_start[2], range_start[3] };
+        for (uint64_t i = 0; i < threadsTotal; ++i) {
+            uint64_t Sc[4]; add256_u64(cur, (uint64_t)half, Sc);
+            h_start_scalars[i*4+0] = Sc[0];
+            h_start_scalars[i*4+1] = Sc[1];
+            h_start_scalars[i*4+2] = Sc[2];
+            h_start_scalars[i*4+3] = Sc[3];
+            uint64_t next[4]; add256(cur, per_thread_cnt, next);
+            cur[0]=next[0]; cur[1]=next[1]; cur[2]=next[2]; cur[3]=next[3];
+        }
+    }
+
+    // Device buffers
+    uint64_t *d_start_scalars=nullptr, *d_Px=nullptr, *d_Py=nullptr,
+             *d_Rx=nullptr,           *d_Ry=nullptr, *d_counts256=nullptr;
+    int            *d_found_flag   = nullptr;
+    FoundResult    *d_found_result = nullptr;
+    unsigned long long *d_hashes_accum = nullptr;
+    unsigned int       *d_any_left     = nullptr;
+
+    ck(cudaMalloc(&d_start_scalars, threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_start_scalars)");
+    ck(cudaMalloc(&d_Px,            threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Px)");
+    ck(cudaMalloc(&d_Py,            threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Py)");
+    ck(cudaMalloc(&d_Rx,            threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Rx)");
+    ck(cudaMalloc(&d_Ry,            threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Ry)");
+    ck(cudaMalloc(&d_counts256,     threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_counts256)");
+    ck(cudaMalloc(&d_found_flag,    sizeof(int)),                         "cudaMalloc(d_found_flag)");
+    ck(cudaMalloc(&d_found_result,  sizeof(FoundResult)),                 "cudaMalloc(d_found_result)");
+    ck(cudaMalloc(&d_hashes_accum,  sizeof(unsigned long long)),          "cudaMalloc(d_hashes_accum)");
+    ck(cudaMalloc(&d_any_left,      sizeof(unsigned int)),                "cudaMalloc(d_any_left)");
+
+    ck(cudaMemcpy(d_start_scalars, h_start_scalars.data(), threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy start_scalars");
+    ck(cudaMemcpy(d_counts256,     h_counts256.data(),     threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy counts256");
+    { int z = FOUND_NONE; unsigned long long z64 = 0ull;
+      ck(cudaMemcpy(d_found_flag,   &z,   sizeof(int),                cudaMemcpyHostToDevice), "init found_flag");
+      ck(cudaMemcpy(d_hashes_accum, &z64, sizeof(unsigned long long), cudaMemcpyHostToDevice), "init hashes_accum"); }
+
+    // Precompute initial EC points
+    {
+        int bs = (int)((threadsTotal + threadsPerBlock - 1) / threadsPerBlock);
+        scalarMulKernelBase<<<bs, threadsPerBlock>>>(d_start_scalars, d_Px, d_Py, (int)threadsTotal);
+        ck(cudaDeviceSynchronize(), "scalarMulKernelBase sync");
+        ck(cudaGetLastError(),      "scalarMulKernelBase launch");
+    }
+
+    // Precompute G*1..G*half → constant memory c_Gx / c_Gy
+    {
+        std::vector<uint64_t> h_scalars_half(half * 4, 0);
+        for (uint32_t k = 0; k < half; ++k) h_scalars_half[(size_t)k*4] = (uint64_t)(k + 1);
+
+        uint64_t *d_sh=nullptr, *d_Gxh=nullptr, *d_Gyh=nullptr;
+        ck(cudaMalloc(&d_sh,  (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_sh)");
+        ck(cudaMalloc(&d_Gxh, (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_Gxh)");
+        ck(cudaMalloc(&d_Gyh, (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_Gyh)");
+        ck(cudaMemcpy(d_sh, h_scalars_half.data(), (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy half scalars");
+
+        int bs = (int)((half + threadsPerBlock - 1) / threadsPerBlock);
+        scalarMulKernelBase<<<bs, threadsPerBlock>>>(d_sh, d_Gxh, d_Gyh, (int)half);
+        ck(cudaDeviceSynchronize(), "scalarMulKernelBase(half) sync");
+        ck(cudaGetLastError(),      "scalarMulKernelBase(half) launch");
+
+        std::vector<uint64_t> h_Gxh(half * 4), h_Gyh(half * 4);
+        ck(cudaMemcpy(h_Gxh.data(), d_Gxh, (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Gx_half");
+        ck(cudaMemcpy(h_Gyh.data(), d_Gyh, (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Gy_half");
+        ck(cudaMemcpyToSymbol(c_Gx, h_Gxh.data(), (size_t)half * 4 * sizeof(uint64_t)), "ToSymbol c_Gx");
+        ck(cudaMemcpyToSymbol(c_Gy, h_Gyh.data(), (size_t)half * 4 * sizeof(uint64_t)), "ToSymbol c_Gy");
+
+        cudaFree(d_sh); cudaFree(d_Gxh); cudaFree(d_Gyh);
+    }
+
+    // Precompute jump point J = G*B → constant memory c_Jx / c_Jy
+    {
+        std::vector<uint64_t> h_scB(4, 0); h_scB[0] = (uint64_t)B;
+        uint64_t *d_scB=nullptr, *d_Jx=nullptr, *d_Jy=nullptr;
+        ck(cudaMalloc(&d_scB, 4 * sizeof(uint64_t)), "cudaMalloc(d_scB)");
+        ck(cudaMalloc(&d_Jx,  4 * sizeof(uint64_t)), "cudaMalloc(d_Jx)");
+        ck(cudaMalloc(&d_Jy,  4 * sizeof(uint64_t)), "cudaMalloc(d_Jy)");
+        ck(cudaMemcpy(d_scB, h_scB.data(), 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy scB");
+
+        scalarMulKernelBase<<<1, 1>>>(d_scB, d_Jx, d_Jy, 1);
+        ck(cudaDeviceSynchronize(), "scalarMulKernelBase(B) sync");
+        ck(cudaGetLastError(),      "scalarMulKernelBase(B) launch");
+
+        uint64_t hJx[4], hJy[4];
+        ck(cudaMemcpy(hJx, d_Jx, 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Jx");
+        ck(cudaMemcpy(hJy, d_Jy, 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Jy");
+        ck(cudaMemcpyToSymbol(c_Jx, hJx, 4 * sizeof(uint64_t)), "ToSymbol c_Jx");
+        ck(cudaMemcpyToSymbol(c_Jy, hJy, 4 * sizeof(uint64_t)), "ToSymbol c_Jy");
+
+        cudaFree(d_scB); cudaFree(d_Jx); cudaFree(d_Jy);
+    }
+
+    // Print GPU info block
+    {
+        size_t freeB=0, totalB=0; cudaMemGetInfo(&freeB, &totalB);
+        double util = totalB ? (double)(totalB - freeB) * 100.0 / (double)totalB : 0.0;
+
+        std::lock_guard<std::mutex> lk(g_print_mutex);
+        std::cout << "======== GPU " << gpu_id << " : " << prop.name
+                  << " (compute " << prop.major << "." << prop.minor << ") ========\n";
+        std::cout << std::left << std::setw(20) << "SM"                 << " : " << prop.multiProcessorCount << "\n";
+        std::cout << std::left << std::setw(20) << "ThreadsPerBlock"    << " : " << threadsPerBlock << "\n";
+        std::cout << std::left << std::setw(20) << "Blocks"             << " : " << blocks << "\n";
+        std::cout << std::left << std::setw(20) << "Total threads"      << " : " << threadsTotal << "\n";
+        std::cout << std::left << std::setw(20) << "Points batch size"  << " : " << B << "\n";
+        std::cout << std::left << std::setw(20) << "Batches/SM"         << " : " << runtime_batches_per_sm << "\n";
+        std::cout << std::left << std::setw(20) << "Batches/launch"     << " : " << slices_per_launch << " (per thread)\n";
+        std::cout << std::left << std::setw(20) << "Memory utilization" << " : "
+                  << std::fixed << std::setprecision(1) << util << "% ("
+                  << human_bytes((double)(totalB - freeB)) << " / " << human_bytes((double)totalB) << ")\n";
+        std::cout << "------------------------------------------------------- \n";
+        std::cout.flush();
+    }
+
+    // Signal init complete
+    shared.init_done.fetch_add(1, std::memory_order_release);
+
+    cudaStream_t streamKernel;
+    ck(cudaStreamCreateWithFlags(&streamKernel, cudaStreamNonBlocking), "create stream");
+    (void)cudaFuncSetCacheConfig(kernel_point_add_and_check_oneinv, cudaFuncCachePreferL1);
+
+    unsigned long long last_hashes_gpu = 0ull;
+    bool stop_all    = false;
+    bool completed_all = false;
+
+    // Random mode: range for chunk selection and RNG
+    uint64_t full_range_len[4];
+    sub256(range_end, range_start, full_range_len);
+    add256_u64(full_range_len, 1ull, full_range_len);
+    // chunk_span = how many keys each random chunk covers (threadsTotal * per_thread_cnt[0])
+    // per_thread_cnt[0] = B * slices in random mode, fits comfortably in uint64_t
+    uint64_t chunk_span = (uint64_t)threadsTotal * per_thread_cnt[0];
+
+    std::mt19937_64 rng_state(
+        (uint64_t)std::chrono::steady_clock::now().time_since_epoch().count()
+        ^ ((uint64_t)gpu_id * 0x9e3779b97f4a7c15ULL)
+    );
+
+    // Fills chunk_start with a random position in [range_start, range_end - chunk_span]
+    auto pick_random_start = [&](uint64_t chunk_start[4]) {
+        // Effective range for chunk selection: range_len - chunk_span
+        // Use __uint128_t; safe for any range up to 2^128
+        __uint128_t rl = ((__uint128_t)full_range_len[1] << 64) | full_range_len[0];
+        if (rl > (__uint128_t)chunk_span) rl -= (__uint128_t)chunk_span;
+        else rl = 1;
+        __uint128_t r = ((__uint128_t)rng_state() << 64) | rng_state();
+        __uint128_t off = r % rl;
+        uint64_t offset[4] = {(uint64_t)off, (uint64_t)(off >> 64), 0, 0};
+        add256(range_start, offset, chunk_start);
+    };
+
+    // Refills h_start_scalars / h_counts256 and reinits EC points for a new chunk
+    auto reinit_chunk = [&](const uint64_t chunk_start[4]) {
+        uint64_t cur[4] = {chunk_start[0], chunk_start[1], chunk_start[2], chunk_start[3]};
+        for (uint64_t i = 0; i < threadsTotal; ++i) {
+            uint64_t Sc[4]; add256_u64(cur, (uint64_t)half, Sc);
+            h_start_scalars[i*4+0] = Sc[0]; h_start_scalars[i*4+1] = Sc[1];
+            h_start_scalars[i*4+2] = Sc[2]; h_start_scalars[i*4+3] = Sc[3];
+            uint64_t next[4]; add256(cur, per_thread_cnt, next);
+            cur[0]=next[0]; cur[1]=next[1]; cur[2]=next[2]; cur[3]=next[3];
+        }
+        for (uint64_t i = 0; i < threadsTotal; ++i) {
+            h_counts256[i*4+0] = per_thread_cnt[0];
+            h_counts256[i*4+1] = per_thread_cnt[1];
+            h_counts256[i*4+2] = per_thread_cnt[2];
+            h_counts256[i*4+3] = per_thread_cnt[3];
+        }
+        cudaMemcpy(d_start_scalars, h_start_scalars.data(),
+                   threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_counts256,     h_counts256.data(),
+                   threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice);
+        int bs = (int)((threadsTotal + threadsPerBlock - 1) / threadsPerBlock);
+        scalarMulKernelBase<<<bs, threadsPerBlock>>>(d_start_scalars, d_Px, d_Py, (int)threadsTotal);
+        cudaDeviceSynchronize();
+    };
+
+    while (!stop_all) {
+        if (shared.any_found.load(std::memory_order_relaxed)) break;
+        if (g_sigint) break;
+
+        // Random mode: always pick a new random position before each kernel launch
+        if (random_mode) {
+            uint64_t chunk_start[4];
+            pick_random_start(chunk_start);
+            reinit_chunk(chunk_start);
+            shared.chunks_tried.fetch_add(1, std::memory_order_relaxed);
+            if (shared.any_found.load(std::memory_order_relaxed)) break;
+            if (g_sigint) break;
+        }
+
+        unsigned int zeroU = 0u;
+        ck(cudaMemcpyAsync(d_any_left, &zeroU, sizeof(unsigned int), cudaMemcpyHostToDevice, streamKernel), "zero d_any_left");
+
+        kernel_point_add_and_check_oneinv<<<blocks, threadsPerBlock, 0, streamKernel>>>(
+            d_Px, d_Py, d_Rx, d_Ry,
+            d_start_scalars, d_counts256,
+            threadsTotal, B, slices_per_launch,
+            d_found_flag, d_found_result,
+            d_hashes_accum, d_any_left
+        );
+        cudaError_t launchErr = cudaGetLastError();
+        if (launchErr != cudaSuccess) {
+            std::lock_guard<std::mutex> lk(g_print_mutex);
+            fprintf(stderr, "\n[GPU %d] Kernel launch error: %s\n", gpu_id, cudaGetErrorString(launchErr));
+            stop_all = true;
+            break;
+        }
+
+        // Poll until kernel finishes
+        while (!stop_all) {
+            if (shared.any_found.load(std::memory_order_relaxed)) {
+                // Another GPU found the key — signal our kernel to exit early
+                int ready = FOUND_READY;
+                cudaMemcpy(d_found_flag, &ready, sizeof(int), cudaMemcpyHostToDevice);
+                stop_all = true;
+                break;
+            }
+            if (g_sigint) { stop_all = true; break; }
+
+            // Accumulate hash count from this GPU into shared counter
+            unsigned long long h_hashes = 0ull;
+            cudaMemcpy(&h_hashes, d_hashes_accum, sizeof(unsigned long long), cudaMemcpyDeviceToHost);
+            if (h_hashes > last_hashes_gpu) {
+                shared.total_hashes.fetch_add(h_hashes - last_hashes_gpu, std::memory_order_relaxed);
+                last_hashes_gpu = h_hashes;
+            }
+
+            int host_found = 0;
+            cudaMemcpy(&host_found, d_found_flag, sizeof(int), cudaMemcpyDeviceToHost);
+            if (host_found == FOUND_READY) {
+                FoundResult res{};
+                cudaMemcpy(&res, d_found_result, sizeof(FoundResult), cudaMemcpyDeviceToHost);
+                {
+                    std::lock_guard<std::mutex> lk(shared.result_mtx);
+                    if (!shared.has_result) {
+                        shared.best_result = res;
+                        shared.has_result  = true;
+                    }
+                }
+                shared.any_found.store(1, std::memory_order_release);
+                stop_all = true;
+                break;
+            }
+
+            cudaError_t qs = cudaStreamQuery(streamKernel);
+            if (qs == cudaSuccess)           break;
+            if (qs != cudaErrorNotReady) { cudaGetLastError(); stop_all = true; break; }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        cudaStreamSynchronize(streamKernel);
+
+        // Final hash flush after sync (memory now fully visible)
+        {
+            unsigned long long h_hashes = 0ull;
+            cudaMemcpy(&h_hashes, d_hashes_accum, sizeof(unsigned long long), cudaMemcpyDeviceToHost);
+            if (h_hashes > last_hashes_gpu) {
+                shared.total_hashes.fetch_add(h_hashes - last_hashes_gpu, std::memory_order_relaxed);
+                last_hashes_gpu = h_hashes;
+            }
+
+            // Re-check found flag after sync — catches the race where cudaStreamQuery
+            // returned success before the polling loop read FOUND_READY
+            if (!stop_all && !shared.any_found.load(std::memory_order_relaxed)) {
+                int host_found = 0;
+                cudaMemcpy(&host_found, d_found_flag, sizeof(int), cudaMemcpyDeviceToHost);
+                if (host_found == FOUND_READY) {
+                    FoundResult res{};
+                    cudaMemcpy(&res, d_found_result, sizeof(FoundResult), cudaMemcpyDeviceToHost);
+                    {
+                        std::lock_guard<std::mutex> lk(shared.result_mtx);
+                        if (!shared.has_result) {
+                            shared.best_result = res;
+                            shared.has_result  = true;
+                        }
+                    }
+                    shared.any_found.store(1, std::memory_order_release);
+                    stop_all = true;
+                }
+            }
+        }
+
+        if (stop_all || g_sigint) break;
+
+        unsigned int h_any = 0u;
+        cudaMemcpy(&h_any, d_any_left, sizeof(unsigned int), cudaMemcpyDeviceToHost);
+
+        if (random_mode) {
+            // Chunk done — loop back to pick a new random position (no swap)
+        } else {
+            std::swap(d_Px, d_Rx);
+            std::swap(d_Py, d_Ry);
+            if (h_any == 0u) { completed_all = true; break; }
+        }
+    }
+
+    cudaDeviceSynchronize();
+
+    cudaFree(d_start_scalars); cudaFree(d_Px); cudaFree(d_Py);
+    cudaFree(d_Rx); cudaFree(d_Ry); cudaFree(d_counts256);
+    cudaFree(d_found_flag); cudaFree(d_found_result);
+    cudaFree(d_hashes_accum); cudaFree(d_any_left);
+    cudaStreamDestroy(streamKernel);
+
+    if (completed_all)
+        shared.gpus_exhausted.fetch_add(1, std::memory_order_relaxed);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 int main(int argc, char** argv) {
     std::signal(SIGINT, handle_sigint);
 
@@ -389,6 +823,7 @@ int main(int argc, char** argv) {
     uint32_t runtime_points_batch_size = 128;
     uint32_t runtime_batches_per_sm    = 8;
     uint32_t slices_per_launch         = 64;
+    bool     random_mode               = false;
 
     auto parse_grid = [](const std::string& s, uint32_t& a_out, uint32_t& b_out)->bool {
         size_t comma = s.find(',');
@@ -435,11 +870,14 @@ int main(int argc, char** argv) {
             }
             slices_per_launch = (uint32_t)v;
         }
+        else if (arg == "--random") {
+            random_mode = true;
+        }
     }
 
     if (range_hex.empty() || (target_hash_hex.empty() && address_b58.empty())) {
         std::cerr << "Usage: " << argv[0]
-                  << " --range <start_hex>:<end_hex> (--address <base58> | --target-hash160 <hash160_hex>) [--grid A,B] [--slices N]\n";
+                  << " --range <start_hex>:<end_hex> (--address <base58> | --target-hash160 <hash160_hex>) [--grid A,B] [--slices N] [--random]\n";
         return EXIT_FAILURE;
     }
     if (!target_hash_hex.empty() && !address_b58.empty()) {
@@ -477,327 +915,158 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    uint64_t range_len[4]; sub256(range_end, range_start, range_len); add256_u64(range_len, 1ull, range_len);
-    uint64_t q_div_batch[4];
-
-    int device=0; cudaDeviceProp prop{};
-    if (cudaGetDevice(&device)!=cudaSuccess || cudaGetDeviceProperties(&prop, device)!=cudaSuccess) {
-        std::cerr<<"CUDA init error\n"; return EXIT_FAILURE;
+    // Detect GPUs
+    int num_gpus = 0;
+    if (cudaGetDeviceCount(&num_gpus) != cudaSuccess || num_gpus == 0) {
+        std::cerr << "No CUDA-capable GPUs found.\n";
+        return EXIT_FAILURE;
     }
 
-    cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
+    // Full range length (for progress display)
+    uint64_t range_len[4];
+    sub256(range_end, range_start, range_len);
+    add256_u64(range_len, 1ull, range_len);
 
-    int threadsPerBlock=256;
-    if (threadsPerBlock > (int)prop.maxThreadsPerBlock) threadsPerBlock=prop.maxThreadsPerBlock;
-    if (threadsPerBlock < 32) threadsPerBlock=32;
+    // In random mode every GPU searches the full range independently.
+    // In sequential mode split evenly across GPUs.
+    std::vector<std::array<uint64_t,4>> gpu_starts(num_gpus), gpu_ends(num_gpus);
+    if (random_mode) {
+        for (int g = 0; g < num_gpus; ++g) {
+            gpu_starts[g] = { range_start[0], range_start[1], range_start[2], range_start[3] };
+            gpu_ends[g]   = { range_end[0],   range_end[1],   range_end[2],   range_end[3]   };
+        }
+    } else {
+    uint64_t per_gpu_len[4]; uint64_t r_gpu = 0ull;
+    divmod_256_by_u64(range_len, (uint64_t)num_gpus, per_gpu_len, r_gpu);
 
-    const uint64_t bytesPerThread = 2ull*4ull*sizeof(uint64_t);
-    size_t totalGlobalMem = prop.totalGlobalMem;
-    const uint64_t reserveBytes = 64ull * 1024 * 1024;
-    uint64_t usableMem = (totalGlobalMem > reserveBytes) ? (totalGlobalMem - reserveBytes) : (totalGlobalMem / 2);
-    uint64_t maxThreadsByMem = usableMem / bytesPerThread;
-
-    // Round range_len up to nearest multiple of batch_size
-    uint64_t r_batch = 0ull;
-    divmod_256_by_u64(range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
-    if (r_batch != 0ull) {
-        uint64_t adjust = (uint64_t)runtime_points_batch_size - r_batch;
-        add256_u64(range_len, adjust, range_len);
-        divmod_256_by_u64(range_len, (uint64_t)runtime_points_batch_size, q_div_batch, r_batch);
-    }
-    bool q_fits_u64 = (q_div_batch[3]|q_div_batch[2]|q_div_batch[1]) == 0ull;
-    if (!q_fits_u64) { std::cerr << "Error: range too large.\n"; return EXIT_FAILURE; }
-    uint64_t total_batches_u64 = q_div_batch[0];
-
-    uint64_t userUpper = (uint64_t)prop.multiProcessorCount * (uint64_t)runtime_batches_per_sm * (uint64_t)threadsPerBlock;
-    if (userUpper == 0ull) userUpper = UINT64_MAX;
-
-    // Pick threadsTotal: pick the max possible, then adjust total_batches to match
-    uint64_t desired_upper = maxThreadsByMem;
-    if (userUpper < desired_upper) desired_upper = userUpper;
-    uint64_t threadsTotal = (desired_upper / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
-    if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
-    if (total_batches_u64 < threadsTotal) {
-        threadsTotal = (total_batches_u64 / (uint64_t)threadsPerBlock) * (uint64_t)threadsPerBlock;
-        if (threadsTotal < (uint64_t)threadsPerBlock) threadsTotal = (uint64_t)threadsPerBlock;
-    }
-    // Adjust total_batches to be divisible by threadsTotal
-    if ((total_batches_u64 % threadsTotal) != 0ull) {
-        uint64_t rem = total_batches_u64 % threadsTotal;
-        total_batches_u64 += threadsTotal - rem;
-        uint64_t add_keys = (threadsTotal - rem) * (uint64_t)runtime_points_batch_size;
-        add256_u64(range_len, add_keys, range_len);
-    }
-
-    int blocks = (int)(threadsTotal / (uint64_t)threadsPerBlock);
-
-    uint64_t per_thread_cnt[4]; uint64_t r_u64 = 0ull;
-    divmod_256_by_u64(range_len, threadsTotal, per_thread_cnt, r_u64);
-
-    uint64_t* h_counts256     = nullptr;
-    uint64_t* h_start_scalars = nullptr;
-    cudaHostAlloc(&h_counts256,     threadsTotal * 4 * sizeof(uint64_t), cudaHostAllocWriteCombined | cudaHostAllocMapped);
-    cudaHostAlloc(&h_start_scalars, threadsTotal * 4 * sizeof(uint64_t), cudaHostAllocWriteCombined | cudaHostAllocMapped);
-
-    for (uint64_t i = 0; i < threadsTotal; ++i) {
-        h_counts256[i*4+0] = per_thread_cnt[0];
-        h_counts256[i*4+1] = per_thread_cnt[1];
-        h_counts256[i*4+2] = per_thread_cnt[2];
-        h_counts256[i*4+3] = per_thread_cnt[3];
-    }
-
-    const uint32_t B = runtime_points_batch_size;
-    const uint32_t half = B >> 1;
     {
         uint64_t cur[4] = { range_start[0], range_start[1], range_start[2], range_start[3] };
-        for (uint64_t i = 0; i < threadsTotal; ++i) {
-            uint64_t Sc[4]; add256_u64(cur, (uint64_t)half, Sc); 
-            h_start_scalars[i*4+0] = Sc[0];
-            h_start_scalars[i*4+1] = Sc[1];
-            h_start_scalars[i*4+2] = Sc[2];
-            h_start_scalars[i*4+3] = Sc[3];
-
-            uint64_t next[4]; add256(cur, per_thread_cnt, next);
-            cur[0]=next[0]; cur[1]=next[1]; cur[2]=next[2]; cur[3]=next[3];
+        for (int g = 0; g < num_gpus; ++g) {
+            gpu_starts[g] = { cur[0], cur[1], cur[2], cur[3] };
+            if (g == num_gpus - 1) {
+                gpu_ends[g] = { range_end[0], range_end[1], range_end[2], range_end[3] };
+            } else {
+                uint64_t next[4]; add256(cur, per_gpu_len, next);
+                uint64_t one[4] = {1,0,0,0};
+                uint64_t end[4]; sub256(next, one, end);
+                gpu_ends[g] = { end[0], end[1], end[2], end[3] };
+                cur[0]=next[0]; cur[1]=next[1]; cur[2]=next[2]; cur[3]=next[3];
+            }
         }
     }
+    } // end else (sequential range split)
 
-    {
-        uint32_t prefix_le = (uint32_t)target_hash160[0]
-                           | ((uint32_t)target_hash160[1] << 8)
-                           | ((uint32_t)target_hash160[2] << 16)
-                           | ((uint32_t)target_hash160[3] << 24);
-        cudaMemcpyToSymbol(c_target_prefix, &prefix_le, sizeof(prefix_le));
-        cudaMemcpyToSymbol(c_target_hash160, target_hash160, 20);
+    std::cout << "======== PrePhase: GPU Information (" << num_gpus
+              << " GPU" << (num_gpus > 1 ? "s" : "") << ") ===\n";
+    for (int g = 0; g < num_gpus; ++g) {
+        cudaDeviceProp p{}; cudaGetDeviceProperties(&p, g);
+        std::cout << "  GPU " << g << " : " << p.name
+                  << "  |  " << p.multiProcessorCount << " SMs"
+                  << "  |  " << human_bytes((double)p.totalGlobalMem) << "\n";
+    }
+    std::cout << "======================================================= \n\n";
+    std::cout.flush();
+
+    GpuShared shared;
+    std::atomic<int> gpus_running{num_gpus};
+
+    std::vector<std::thread> gpu_threads;
+    gpu_threads.reserve(num_gpus);
+    for (int g = 0; g < num_gpus; ++g) {
+        gpu_threads.emplace_back([&, g]() {
+            run_on_gpu(g,
+                       gpu_starts[g].data(), gpu_ends[g].data(),
+                       target_hash160,
+                       runtime_points_batch_size, runtime_batches_per_sm, slices_per_launch,
+                       random_mode,
+                       shared);
+            gpus_running.fetch_sub(1, std::memory_order_relaxed);
+        });
     }
 
-    uint64_t *d_start_scalars=nullptr, *d_Px=nullptr, *d_Py=nullptr, *d_Rx=nullptr, *d_Ry=nullptr, *d_counts256=nullptr;
-    int *d_found_flag=nullptr; FoundResult *d_found_result=nullptr;
-    unsigned long long *d_hashes_accum=nullptr; unsigned int *d_any_left=nullptr;
-
-    auto ck = [](cudaError_t e, const char* msg){
-        if (e != cudaSuccess) {
-            std::cerr << msg << ": " << cudaGetErrorString(e) << "\n";
-            std::exit(EXIT_FAILURE);
-        }
-    };
-
-    ck(cudaMalloc(&d_start_scalars, threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_start_scalars)");
-    ck(cudaMalloc(&d_Px,           threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Px)");
-    ck(cudaMalloc(&d_Py,           threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Py)");
-    ck(cudaMalloc(&d_Rx,           threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Rx)");
-    ck(cudaMalloc(&d_Ry,           threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_Ry)");
-    ck(cudaMalloc(&d_counts256,    threadsTotal * 4 * sizeof(uint64_t)), "cudaMalloc(d_counts256)");
-    ck(cudaMalloc(&d_found_flag,   sizeof(int)),                         "cudaMalloc(d_found_flag)");
-    ck(cudaMalloc(&d_found_result, sizeof(FoundResult)),                 "cudaMalloc(d_found_result)");
-    ck(cudaMalloc(&d_hashes_accum, sizeof(unsigned long long)),          "cudaMalloc(d_hashes_accum)");
-    ck(cudaMalloc(&d_any_left,     sizeof(unsigned int)),                "cudaMalloc(d_any_left)");
-
-    ck(cudaMemcpy(d_start_scalars, h_start_scalars, threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy start_scalars");
-    ck(cudaMemcpy(d_counts256,     h_counts256,     threadsTotal * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy counts256");
-    { int zero = FOUND_NONE; unsigned long long zero64=0ull;
-      ck(cudaMemcpy(d_found_flag, &zero,   sizeof(int),                cudaMemcpyHostToDevice), "init found_flag");
-      ck(cudaMemcpy(d_hashes_accum, &zero64, sizeof(unsigned long long), cudaMemcpyHostToDevice), "init hashes_accum"); }
-
-    {
-        int blocks_scal = (int)((threadsTotal + threadsPerBlock - 1) / threadsPerBlock);
-        scalarMulKernelBase<<<blocks_scal, threadsPerBlock>>>(d_start_scalars, d_Px, d_Py, (int)threadsTotal);
-        ck(cudaDeviceSynchronize(), "scalarMulKernelBase sync");
-        ck(cudaGetLastError(), "scalarMulKernelBase launch");
+    // Wait for all GPUs to finish init before starting display
+    while (shared.init_done.load(std::memory_order_acquire) < num_gpus) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (g_sigint) break;
     }
 
-    {
-        uint64_t* h_scalars_half = nullptr;
-        cudaHostAlloc(&h_scalars_half, (size_t)half * 4 * sizeof(uint64_t), cudaHostAllocWriteCombined | cudaHostAllocMapped);
-        std::memset(h_scalars_half, 0, (size_t)half * 4 * sizeof(uint64_t));
-        for (uint32_t k = 0; k < half; ++k) h_scalars_half[(size_t)k*4 + 0] = (uint64_t)(k + 1);
-
-        uint64_t *d_scalars_half=nullptr, *d_Gx_half=nullptr, *d_Gy_half=nullptr;
-        ck(cudaMalloc(&d_scalars_half, (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_scalars_half)");
-        ck(cudaMalloc(&d_Gx_half,      (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_Gx_half)");
-        ck(cudaMalloc(&d_Gy_half,      (size_t)half * 4 * sizeof(uint64_t)), "cudaMalloc(d_Gy_half)");
-        ck(cudaMemcpy(d_scalars_half, h_scalars_half, (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy half scalars");
-
-        int blocks_scal = (int)((half + threadsPerBlock - 1) / threadsPerBlock);
-        scalarMulKernelBase<<<blocks_scal, threadsPerBlock>>>(d_scalars_half, d_Gx_half, d_Gy_half, (int)half);
-        ck(cudaDeviceSynchronize(), "scalarMulKernelBase(half) sync");
-        ck(cudaGetLastError(), "scalarMulKernelBase(half) launch");
-
-        uint64_t* h_Gx_half = (uint64_t*)std::malloc((size_t)half * 4 * sizeof(uint64_t));
-        uint64_t* h_Gy_half = (uint64_t*)std::malloc((size_t)half * 4 * sizeof(uint64_t));
-        ck(cudaMemcpy(h_Gx_half, d_Gx_half, (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Gx_half");
-        ck(cudaMemcpy(h_Gy_half, d_Gy_half, (size_t)half * 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Gy_half");
-        ck(cudaMemcpyToSymbol(c_Gx, h_Gx_half, (size_t)half * 4 * sizeof(uint64_t)), "ToSymbol c_Gx");
-        ck(cudaMemcpyToSymbol(c_Gy, h_Gy_half, (size_t)half * 4 * sizeof(uint64_t)), "ToSymbol c_Gy");
-
-        cudaFree(d_scalars_half); cudaFree(d_Gx_half); cudaFree(d_Gy_half);
-        cudaFreeHost(h_scalars_half);
-        std::free(h_Gx_half); std::free(h_Gy_half);
+    std::cout << "\n======== Phase-1: " << (random_mode ? "Lottery / Random Jump" : "BruteForce") << " ("
+              << num_gpus << " GPU" << (num_gpus > 1 ? "s" : "") << ") =====\n";
+    if (random_mode) {
+        uint64_t ck = (uint64_t)runtime_points_batch_size * slices_per_launch;
+        std::string ck_s;
+        if      (ck >= 1000000000ULL) ck_s = std::to_string(ck/1000000000ULL) + "G";
+        else if (ck >= 1000000ULL)    ck_s = std::to_string(ck/1000000ULL)    + "M";
+        else if (ck >= 1000ULL)       ck_s = std::to_string(ck/1000ULL)       + "K";
+        else                          ck_s = std::to_string(ck);
+        std::cout << "(random mode: ~" << ck_s
+                  << " keys/thread per chunk; lower --slices = more frequent jumps)\n";
     }
-    {
-        uint64_t* h_scalarB = nullptr;
-        cudaHostAlloc(&h_scalarB, 4 * sizeof(uint64_t), cudaHostAllocWriteCombined | cudaHostAllocMapped);
-        std::memset(h_scalarB, 0, 4 * sizeof(uint64_t));
-        h_scalarB[0] = (uint64_t)B;
+    std::cout.flush();
 
-        uint64_t *d_scalarB=nullptr, *d_Jx=nullptr, *d_Jy=nullptr;
-        ck(cudaMalloc(&d_scalarB, 4 * sizeof(uint64_t)), "cudaMalloc(d_scalarB)");
-        ck(cudaMalloc(&d_Jx,      4 * sizeof(uint64_t)), "cudaMalloc(d_Jx)");
-        ck(cudaMalloc(&d_Jy,      4 * sizeof(uint64_t)), "cudaMalloc(d_Jy)");
-        ck(cudaMemcpy(d_scalarB, h_scalarB, 4 * sizeof(uint64_t), cudaMemcpyHostToDevice), "cpy scalarB");
-
-        scalarMulKernelBase<<<1, 1>>>(d_scalarB, d_Jx, d_Jy, 1);
-        ck(cudaDeviceSynchronize(), "scalarMulKernelBase(B) sync");
-        ck(cudaGetLastError(), "scalarMulKernelBase(B) launch");
-
-        uint64_t hJx[4], hJy[4];
-        ck(cudaMemcpy(hJx, d_Jx, 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Jx");
-        ck(cudaMemcpy(hJy, d_Jy, 4 * sizeof(uint64_t), cudaMemcpyDeviceToHost), "D2H Jy");
-        ck(cudaMemcpyToSymbol(c_Jx, hJx, 4 * sizeof(uint64_t)), "ToSymbol c_Jx");
-        ck(cudaMemcpyToSymbol(c_Jy, hJy, 4 * sizeof(uint64_t)), "ToSymbol c_Jy");
-
-        cudaFree(d_scalarB); cudaFree(d_Jx); cudaFree(d_Jy);
-        cudaFreeHost(h_scalarB);
-    }
-
-    size_t freeB=0,totalB=0; cudaMemGetInfo(&freeB,&totalB);
-    size_t usedB = totalB - freeB;
-    double util = totalB ? (double)usedB * 100.0 / (double)totalB : 0.0;
-
-    std::cout << "======== PrePhase: GPU Information ====================\n";
-    std::cout << std::left << std::setw(20) << "Device"            << " : " << prop.name << " (compute " << prop.major << "." << prop.minor << ")\n";
-    std::cout << std::left << std::setw(20) << "SM"                << " : " << prop.multiProcessorCount << "\n";
-    std::cout << std::left << std::setw(20) << "ThreadsPerBlock"   << " : " << threadsPerBlock << "\n";
-    std::cout << std::left << std::setw(20) << "Blocks"            << " : " << (int)(threadsTotal / (uint64_t)threadsPerBlock) << "\n";
-    std::cout << std::left << std::setw(20) << "Points batch size" << " : " << B << "\n";
-    std::cout << std::left << std::setw(20) << "Batches/SM"        << " : " << runtime_batches_per_sm << "\n";
-    std::cout << std::left << std::setw(20) << "Batches/launch"    << " : " << slices_per_launch << " (per thread)\n";
-    std::cout << std::left << std::setw(20) << "Memory utilization"<< " : "
-              << std::fixed << std::setprecision(1) << util << "% ("
-              << human_bytes((double)usedB) << " / " << human_bytes((double)totalB) << ")\n";
-    std::cout << "------------------------------------------------------- \n";
-    std::cout << std::left << std::setw(20) << "Total threads"     << " : " << (uint64_t)threadsTotal << "\n\n";
-    std::cout << "======== Phase-1: BruteForce ==========================\n";
-
-    cudaStream_t streamKernel;
-    ck(cudaStreamCreateWithFlags(&streamKernel, cudaStreamNonBlocking), "create stream");
-
-    (void)cudaFuncSetCacheConfig(kernel_point_add_and_check_oneinv, cudaFuncCachePreferL1);
-
-    auto t0 = std::chrono::high_resolution_clock::now();
+    auto t0    = std::chrono::high_resolution_clock::now();
     auto tLast = t0;
     unsigned long long lastHashes = 0ull;
+    long double total_keys_ld = ld_from_u256(range_len);
 
-    bool stop_all = false;
-    bool completed_all = false;
-    while (!stop_all) {
-        if (g_sigint) std::cerr << "\n[Ctrl+C] Interrupt received. Finishing current kernel slice and exiting...\n";
+    while (gpus_running.load(std::memory_order_relaxed) > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-        unsigned int zeroU = 0u;
-        ck(cudaMemcpyAsync(d_any_left, &zeroU, sizeof(unsigned int), cudaMemcpyHostToDevice, streamKernel), "zero d_any_left");
+        auto now = std::chrono::high_resolution_clock::now();
+        double dt = std::chrono::duration<double>(now - tLast).count();
+        if (dt >= 1.0) {
+            unsigned long long h_hashes = shared.total_hashes.load(std::memory_order_relaxed);
+            double delta  = (double)(h_hashes - lastHashes);
+            double mkeys  = delta / (dt * 1e6);
+            double elapsed = std::chrono::duration<double>(now - t0).count();
+            long double prog = total_keys_ld > 0.0L
+                               ? ((long double)h_hashes / total_keys_ld) * 100.0L : 0.0L;
+            if (prog > 100.0L) prog = 100.0L;
 
-        kernel_point_add_and_check_oneinv<<<blocks, threadsPerBlock, 0, streamKernel>>>(
-            d_Px, d_Py, d_Rx, d_Ry,
-            d_start_scalars, d_counts256,
-            threadsTotal,
-            B,
-            slices_per_launch,
-            d_found_flag, d_found_result,
-            d_hashes_accum,
-            d_any_left
-        );
-        cudaError_t launchErr = cudaGetLastError();
-        if (launchErr != cudaSuccess) {
-            std::cerr << "\nKernel launch error: " << cudaGetErrorString(launchErr) << "\n";
-            stop_all = true;
-        }
+            double speed_val = mkeys;
+            const char* speed_unit = "Mkeys/s";
+            if (speed_val >= 1000000.0) { speed_val /= 1000000.0; speed_unit = "Tkeys/s"; }
+            else if (speed_val >= 1000.0) { speed_val /= 1000.0;  speed_unit = "Gkeys/s"; }
 
-        while (!stop_all) {
-            auto now = std::chrono::high_resolution_clock::now();
-            double dt = std::chrono::duration<double>(now - tLast).count();
-            if (dt >= 1.0) {
-                unsigned long long h_hashes = 0ull;
-                ck(cudaMemcpy(&h_hashes, d_hashes_accum, sizeof(unsigned long long), cudaMemcpyDeviceToHost), "read hashes");
-                double delta = (double)(h_hashes - lastHashes);
-                double mkeys = delta / (dt * 1e6);
-                double elapsed = std::chrono::duration<double>(now - t0).count();
-                long double total_keys_ld = ld_from_u256(range_len);
-                long double prog = total_keys_ld > 0.0L ? ((long double)h_hashes / total_keys_ld) * 100.0L : 0.0L;
-                if (prog > 100.0L) prog = 100.0L;
-                double speed_val = mkeys;
-                const char* speed_unit = "Mkeys/s";
-                if (speed_val >= 1000000.0) {
-                    speed_val /= 1000000.0;
-                    speed_unit = "Tkeys/s";
-                } else if (speed_val >= 1000.0) {
-                    speed_val /= 1000.0;
-                    speed_unit = "Gkeys/s";
-                }
+            if (random_mode) {
+                unsigned long long chunks = shared.chunks_tried.load(std::memory_order_relaxed);
+                std::cout << "\rTime: " << std::fixed << std::setprecision(1) << std::setw(6) << elapsed
+                          << " s | Speed: " << std::fixed << std::setprecision(2) << std::setw(7) << speed_val
+                          << " " << speed_unit << " | Count: " << std::setw(14) << h_hashes
+                          << " | Chunks: " << std::setw(6) << chunks << "   ";
+            } else {
                 std::cout << "\rTime: " << std::fixed << std::setprecision(1) << std::setw(6) << elapsed
                           << " s | Speed: " << std::fixed << std::setprecision(2) << std::setw(7) << speed_val
                           << " " << speed_unit << " | Count: " << std::setw(14) << h_hashes
                           << " | Progress: " << std::fixed << std::setprecision(2) << std::setw(6) << (double)prog << " %   ";
-                std::cout.flush();
-                lastHashes = h_hashes; tLast = now;
             }
-
-            int host_found = 0;
-            ck(cudaMemcpy(&host_found, d_found_flag, sizeof(int), cudaMemcpyDeviceToHost), "read found_flag");
-            if (host_found == FOUND_READY) { stop_all = true; break; }
-
-            cudaError_t qs = cudaStreamQuery(streamKernel);
-            if (qs == cudaSuccess) break;
-            else if (qs != cudaErrorNotReady) { cudaGetLastError(); stop_all = true; break; }
-
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            std::cout.flush();
+            lastHashes = h_hashes; tLast = now;
         }
 
-        cudaStreamSynchronize(streamKernel);
-        std::cout.flush();
-        if (stop_all || g_sigint) break;
-
-        unsigned int h_any = 0u;
-        ck(cudaMemcpy(&h_any, d_any_left, sizeof(unsigned int), cudaMemcpyDeviceToHost), "read any_left");
-
-        std::swap(d_Px, d_Rx);
-        std::swap(d_Py, d_Ry);
-
-        if (h_any == 0u) { completed_all = true; break; }
+        if (g_sigint) break;
     }
 
-    cudaDeviceSynchronize();
-    std::cout << "\n";
+    for (auto& t : gpu_threads) t.join();
 
-    int h_found_flag = 0;
-    ck(cudaMemcpy(&h_found_flag, d_found_flag, sizeof(int), cudaMemcpyDeviceToHost), "final read found_flag");
+    std::cout << "\n";
 
     int exit_code = EXIT_SUCCESS;
 
-    if (h_found_flag == FOUND_READY) {
-        FoundResult host_result{};
-        ck(cudaMemcpy(&host_result, d_found_result, sizeof(FoundResult), cudaMemcpyDeviceToHost), "read found_result");
+    if (shared.has_result) {
         std::cout << "\n======== FOUND MATCH! =================================\n";
-        std::cout << "Private Key   : " << formatHex256(host_result.scalar) << "\n";
-        std::cout << "Public Key    : " << formatCompressedPubHex(host_result.Rx, host_result.Ry) << "\n";
+        std::cout << "Private Key   : " << formatHex256(shared.best_result.scalar) << "\n";
+        std::cout << "Public Key    : " << formatCompressedPubHex(shared.best_result.Rx, shared.best_result.Ry) << "\n";
+    } else if (g_sigint) {
+        std::cout << "======== INTERRUPTED (Ctrl+C) ==========================\n";
+        std::cout << "Search was interrupted by user. Partial progress above.\n";
+        exit_code = 130;
+    } else if (shared.gpus_exhausted.load() >= num_gpus) {
+        std::cout << "======== KEY NOT FOUND (exhaustive) ===================\n";
+        std::cout << "Target hash160 was not found within the specified range.\n";
     } else {
-        if (g_sigint) {
-            std::cout << "======== INTERRUPTED (Ctrl+C) ==========================\n";
-            std::cout << "Search was interrupted by user. Partial progress above.\n";
-            exit_code = 130;
-        } else if (completed_all) {
-            std::cout << "======== KEY NOT FOUND (exhaustive) ===================\n";
-            std::cout << "Target hash160 was not found within the specified range.\n";
-        } else {
-            std::cout << "======== TERMINATED ===================================\n";
-        }
+        std::cout << "======== TERMINATED ===================================\n";
     }
-
-    cudaFree(d_start_scalars); cudaFree(d_Px); cudaFree(d_Py); cudaFree(d_Rx); cudaFree(d_Ry);
-    cudaFree(d_counts256); cudaFree(d_found_flag); cudaFree(d_found_result); cudaFree(d_hashes_accum); cudaFree(d_any_left);
-    cudaStreamDestroy(streamKernel);
-
-    if (h_start_scalars) cudaFreeHost(h_start_scalars);
-    if (h_counts256)     cudaFreeHost(h_counts256);
 
     return exit_code;
 }

--- a/CUDAMath.h
+++ b/CUDAMath.h
@@ -1,7 +1,6 @@
 #define NBBLOCK 5
 #define BIFULLSIZE 40
 
-
 #define UADDO(c, a, b) asm volatile ("add.cc.u64 %0, %1, %2;" : "=l"(c) : "l"(a), "l"(b) : "memory" );
 #define UADDC(c, a, b) asm volatile ("addc.cc.u64 %0, %1, %2;" : "=l"(c) : "l"(a), "l"(b) : "memory" );
 #define UADD(c, a, b) asm volatile ("addc.u64 %0, %1, %2;" : "=l"(c) : "l"(a), "l"(b));
@@ -979,79 +978,58 @@ __device__ __forceinline__ bool fieldIsZero(const uint64_t a[4]) {
 }
 
 __device__ void fieldAdd(const uint64_t a[4], const uint64_t b[4], uint64_t out[4]) {
-    __uint128_t t = 0;
-    uint64_t c = 0;
+    uint64_t carry = 0;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        uint64_t s = a[i] + b[i];
+        uint64_t c = (s < a[i]) ? 1ULL : 0ULL;
+        s += carry;
+        if (s < carry) c = 1ULL;
+        out[i] = s;
+        carry = c;
+    }
 
-    t = (__uint128_t)a[0] + b[0];
-    out[0] = (uint64_t)t;
-    c = (uint64_t)(t >> 64);
-
-    t = (__uint128_t)a[1] + b[1] + c;
-    out[1] = (uint64_t)t;
-    c = (uint64_t)(t >> 64);
-
-    t = (__uint128_t)a[2] + b[2] + c;
-    out[2] = (uint64_t)t;
-    c = (uint64_t)(t >> 64);
-
-    t = (__uint128_t)a[3] + b[3] + c;
-    out[3] = (uint64_t)t;
-    c = (uint64_t)(t >> 64); 
-
-    if (c || (out[3] > SECP_P_LE[3]) || 
+    if (carry || (out[3] > SECP_P_LE[3]) || 
         (out[3] == SECP_P_LE[3] && out[2] > SECP_P_LE[2]) || 
         (out[3] == SECP_P_LE[3] && out[2] == SECP_P_LE[2] && out[1] > SECP_P_LE[1]) || 
         (out[3] == SECP_P_LE[3] && out[2] == SECP_P_LE[2] && out[1] == SECP_P_LE[1] && out[0] >= SECP_P_LE[0])) {
 
-        __uint128_t tb;
         uint64_t borrow = 0;
-        tb = (__uint128_t)out[0] - SECP_P_LE[0];
-        out[0] = (uint64_t)tb;
-        borrow = (tb > 0xFFFFFFFFFFFFFFFFULL) ? 1 : 0;
-
-        tb = (__uint128_t)out[1] - SECP_P_LE[1] - borrow;
-        out[1] = (uint64_t)tb;
-        borrow = (tb > 0xFFFFFFFFFFFFFFFFULL) ? 1 : 0;
-
-        tb = (__uint128_t)out[2] - SECP_P_LE[2] - borrow;
-        out[2] = (uint64_t)tb;
-        borrow = (tb > 0xFFFFFFFFFFFFFFFFULL) ? 1 : 0;
-
-        tb = (__uint128_t)out[3] - SECP_P_LE[3] - borrow;
-        out[3] = (uint64_t)tb;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            uint64_t diff = out[i] - borrow;
+            uint64_t nb = (diff > out[i]) ? 1ULL : 0ULL;
+            uint64_t diff2 = diff - SECP_P_LE[i];
+            if (diff2 > diff) nb = 1ULL;
+            out[i] = diff2;
+            borrow = nb;
+        }
     }
 }
 
 __device__ void fieldSub(const uint64_t a[4], const uint64_t b[4], uint64_t out[4]) {
-    __int128_t t;
     uint64_t borrow = 0;
-
-    t = (__int128_t)a[0] - b[0];
-    out[0] = (uint64_t)t; borrow = (t < 0);
-
-    t = (__int128_t)a[1] - b[1] - borrow;
-    out[1] = (uint64_t)t; borrow = (t < 0);
-
-    t = (__int128_t)a[2] - b[2] - borrow;
-    out[2] = (uint64_t)t; borrow = (t < 0);
-
-    t = (__int128_t)a[3] - b[3] - borrow;
-    out[3] = (uint64_t)t; borrow = (t < 0);
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        uint64_t diff = a[i] - borrow;
+        uint64_t nb = (diff > a[i]) ? 1ULL : 0ULL;
+        uint64_t diff2 = diff - b[i];
+        if (diff2 > diff) nb = 1ULL;
+        out[i] = diff2;
+        borrow = nb;
+    }
 
     if (borrow) {
-        __uint128_t tu;
         uint64_t carry = 0;
-        tu = (__uint128_t)out[0] + SECP_P_LE[0];
-        out[0] = (uint64_t)tu; carry = (uint64_t)(tu >> 64);
-
-        tu = (__uint128_t)out[1] + SECP_P_LE[1] + carry;
-        out[1] = (uint64_t)tu; carry = (uint64_t)(tu >> 64);
-
-        tu = (__uint128_t)out[2] + SECP_P_LE[2] + carry;
-        out[2] = (uint64_t)tu; carry = (uint64_t)(tu >> 64);
-
-        tu = (__uint128_t)out[3] + SECP_P_LE[3] + carry;
-        out[3] = (uint64_t)tu;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            uint64_t s = out[i] + SECP_P_LE[i];
+            uint64_t c = (s < out[i]) ? 1ULL : 0ULL;
+            s += carry;
+            if (s < carry) c = 1ULL;
+            out[i] = s;
+            carry = c;
+        }
     }
 }
 

--- a/CUDAUtils.h
+++ b/CUDAUtils.h
@@ -1,55 +1,63 @@
+#if defined(_MSC_VER) && !defined(__CUDA_ARCH__)
+#include <intrin.h>
+#endif
+
 __host__ __forceinline__ void add256_u64(const uint64_t a[4], uint64_t b, uint64_t out[4]) {
-    __uint128_t sum = (__uint128_t)a[0] + b;
-    out[0] = (uint64_t)sum;
-    uint64_t carry = (uint64_t)(sum >> 64);
+    out[0] = a[0] + b;
+    uint64_t carry = (out[0] < a[0]) ? 1ULL : 0ULL;
     for (int i = 1; i < 4; ++i) {
-        sum = (__uint128_t)a[i] + carry;
-        out[i] = (uint64_t)sum;
-        carry = (uint64_t)(sum >> 64);
+        out[i] = a[i] + carry;
+        carry = (out[i] < a[i]) ? 1ULL : 0ULL;
     }
 }
 
 __host__ __forceinline__ void add256(const uint64_t a[4], const uint64_t b[4], uint64_t out[4]) {
-    __uint128_t carry = 0;
+    uint64_t carry = 0;
     for (int i = 0; i < 4; ++i) {
-        __uint128_t s = (__uint128_t)a[i] + b[i] + carry;
-        out[i] = (uint64_t)s;
-        carry = s >> 64;
+        uint64_t s = a[i] + b[i];
+        uint64_t c = (s < a[i]) ? 1ULL : 0ULL;
+        uint64_t s2 = s + carry;
+        if (s2 < s) c = 1ULL;
+        out[i] = s2;
+        carry = c;
     }
 }
 
 __host__ __forceinline__ void sub256(const uint64_t a[4], const uint64_t b[4], uint64_t out[4]) {
     uint64_t borrow = 0;
     for (int i = 0; i < 4; ++i) {
-        uint64_t bi = b[i] + borrow;
-        if (a[i] < bi) {
-            out[i] = (uint64_t)(((__uint128_t(1) << 64) + a[i]) - bi);
-            borrow = 1;
-        } else {
-            out[i] = a[i] - bi;
-            borrow = 0;
-        }
+        uint64_t diff = a[i] - borrow;
+        uint64_t nb = (diff > a[i]) ? 1ULL : 0ULL;
+        uint64_t diff2 = diff - b[i];
+        if (diff2 > diff) nb = 1ULL;
+        out[i] = diff2;
+        borrow = nb;
     }
 }
 
 __host__ __forceinline__ void inc256(uint64_t a[4], uint64_t inc) {
-    __uint128_t cur = (__uint128_t)a[0] + inc;
-    a[0] = (uint64_t)cur;
-    uint64_t carry = (uint64_t)(cur >> 64);
+    a[0] += inc;
+    uint64_t carry = (a[0] < inc) ? 1ULL : 0ULL;
     for (int i = 1; i < 4 && carry; ++i) {
-        cur = (__uint128_t)a[i] + carry;
-        a[i] = (uint64_t)cur;
-        carry = (uint64_t)(cur >> 64);
+        ++a[i];
+        carry = (a[i] == 0ULL) ? 1ULL : 0ULL;
     }
 }
 
 __host__ void divmod_256_by_u64(const uint64_t value[4], uint64_t divisor, uint64_t quotient[4], uint64_t &remainder) {
+#ifdef _MSC_VER
+    remainder = 0;
+    for (int i = 3; i >= 0; --i) {
+        quotient[i] = _udiv128(remainder, value[i], divisor, &remainder);
+    }
+#else
     remainder = 0;
     for (int i = 3; i >= 0; --i) {
         __uint128_t cur = (__uint128_t(remainder) << 64) | value[i];
         quotient[i] = (uint64_t)(cur / divisor);
         remainder = (uint64_t)(cur % divisor);
     }
+#endif
 }
 
 bool hexToLE64(const std::string& h_in, uint64_t w[4]) {
@@ -82,13 +90,12 @@ std::string formatHex256(const uint64_t limbs[4]) {
 }
 
 __device__ __forceinline__ void inc256_device(uint64_t a[4], uint64_t inc) {
-    unsigned __int128 cur = (unsigned __int128)a[0] + inc;
-    a[0] = (uint64_t)cur;
-    uint64_t carry = (uint64_t)(cur >> 64);
+    uint64_t sum = a[0] + inc;
+    a[0] = sum;
+    uint64_t carry = (sum < inc) ? 1ULL : 0ULL;
     for (int i = 1; i < 4 && carry; ++i) {
-        cur = (unsigned __int128)a[i] + carry;
-        a[i] = (uint64_t)cur;
-        carry = (uint64_t)(cur >> 64);
+        ++a[i];
+        carry = (a[i] == 0ULL) ? 1ULL : 0ULL;
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ifeq ($(OS),Windows_NT)
   TARGET_EXT := .exe
   OBJ_EXT    := .obj
-  RM         := del /Q /F
+  RM         := cmd /c del /Q /F
 else
   TARGET_EXT :=
   OBJ_EXT    := .o

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,32 @@
-TARGET      := CUDACyclone
+# ── Detectar plataforma ──────────────────────────
+ifeq ($(OS),Windows_NT)
+  TARGET_EXT := .exe
+  OBJ_EXT    := .obj
+  RM         := del /Q /F
+else
+  TARGET_EXT :=
+  OBJ_EXT    := .o
+  RM         := rm -f
+endif
+
+TARGET      := CUDACyclone$(TARGET_EXT)
 SRC         := CUDACyclone.cu CUDAHash.cu
-OBJ         := $(SRC:.cu=.o)
+OBJ         := $(SRC:.cu=$(OBJ_EXT))
 CC          := nvcc
 
-GPU_ARCH ?= $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n1 | tr -d '.')
+# Detecta compute capability da GPU automaticamente
+# Windows: usa PowerShell (consegue acessar nvidia-smi no PATH)
+# Linux: usa shell normal
+ifeq ($(OS),Windows_NT)
+  GPU_ARCH ?= $(strip $(shell powershell -NoProfile -Command "try{ (nvidia-smi --query-gpu=compute_cap --format=csv,noheader | Select-Object -First 1).Trim() -replace '\.','' }catch{''}" 2>nul))
+else
+  GPU_ARCH ?= $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -n1 | tr -d '.')
+endif
+ifeq ($(GPU_ARCH),)
+  GPU_ARCH := 86
+  $(warning nvidia-smi nao disponivel. Usando GPU_ARCH=86 como fallback.)
+endif
+
 SM_ARCHS   := 75 86 89 $(GPU_ARCH)
 GENCODE    := $(foreach arch,$(SM_ARCHS),-gencode arch=compute_$(arch),code=sm_$(arch))
 
@@ -17,9 +40,9 @@ all: $(TARGET)
 $(TARGET): $(OBJ)
 	$(CC) $(NVCC_FLAGS) $(CXXFLAGS) $(OBJ) -o $@ $(LDFLAGS)
 
-%.o: %.cu
+%$(OBJ_EXT): %.cu
 	$(CC) $(NVCC_FLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(TARGET) $(OBJ)
+	$(RM) $(TARGET) $(OBJ)
 

--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,5 @@ $(TARGET): $(OBJ)
 	$(CC) $(NVCC_FLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	$(RM) $(TARGET) $(OBJ)
+	-$(RM) $(TARGET) $(OBJ)
 

--- a/Makefile
+++ b/Makefile
@@ -14,20 +14,20 @@ SRC         := CUDACyclone.cu CUDAHash.cu
 OBJ         := $(SRC:.cu=$(OBJ_EXT))
 CC          := nvcc
 
-# Detecta compute capability da GPU automaticamente
+# Detecta compute capability de TODAS as GPUs instaladas
 # Windows: usa PowerShell (consegue acessar nvidia-smi no PATH)
 # Linux: usa shell normal
 ifeq ($(OS),Windows_NT)
-  GPU_ARCH ?= $(strip $(shell powershell -NoProfile -Command "try{ (nvidia-smi --query-gpu=compute_cap --format=csv,noheader | Select-Object -First 1).Trim() -replace '\.','' }catch{''}" 2>nul))
+  GPU_ARCHS ?= $(sort $(strip $(shell powershell -NoProfile -Command "try{ (nvidia-smi --query-gpu=compute_cap --format=csv,noheader) -replace '\.','' -join ' ' }catch{''}" 2>nul)))
 else
-  GPU_ARCH ?= $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -n1 | tr -d '.')
+  GPU_ARCHS ?= $(sort $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | sed 's/\.//' | tr '\n' ' '))
 endif
-ifeq ($(GPU_ARCH),)
-  GPU_ARCH := 86
-  $(warning nvidia-smi nao disponivel. Usando GPU_ARCH=86 como fallback.)
+ifeq ($(GPU_ARCHS),)
+  GPU_ARCHS := 86
+  $(warning nvidia-smi nao disponivel. Usando GPU_ARCHS=86 como fallback.)
 endif
 
-SM_ARCHS   := 75 86 89 $(GPU_ARCH)
+SM_ARCHS   := $(sort 75 86 89 $(GPU_ARCHS))
 GENCODE    := $(foreach arch,$(SM_ARCHS),-gencode arch=compute_$(arch),code=sm_$(arch))
 
 NVCC_FLAGS := -O3 -rdc=true -use_fast_math --ptxas-options=-O3 -allow-unsupported-compiler $(GENCODE)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ifeq ($(OS),Windows_NT)
   TARGET_EXT := .exe
   OBJ_EXT    := .obj
-  RM         := cmd /c del /Q /F
+  RM         := cmd /c del /Q /F 2>nul
 else
   TARGET_EXT :=
   OBJ_EXT    := .o

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 SM_ARCHS   := 75 86 89 $(GPU_ARCH)
 GENCODE    := $(foreach arch,$(SM_ARCHS),-gencode arch=compute_$(arch),code=sm_$(arch))
 
-NVCC_FLAGS := -O3 -rdc=true -use_fast_math --ptxas-options=-O3 $(GENCODE)
+NVCC_FLAGS := -O3 -rdc=true -use_fast_math --ptxas-options=-O3 -allow-unsupported-compiler $(GENCODE)
 CXXFLAGS   := -std=c++17
 
 LDFLAGS    := -lcudadevrt -cudart=static

--- a/README.md
+++ b/README.md
@@ -230,4 +230,4 @@ Thanks to the original work that served as the foundation for this project.
 ---
 
 ## ✌️**TIPS**
-BTC: bc1qtq4y9l9ajeyxq05ynq09z8p52xdmk4hqky9c8n
+BTC: bc1q7s4m9cwlq8xtx2nz74mquh6ax0jqwsmkkd56s3

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I fixed this problem, to make sure that keys are not skipped I wrote a small scr
 The script is called **proof.py**. The script generates random scalars in a given range, calculates addresses, then runs Cyclone and at the end of the work shows how many keys were found and how many were not found. All should be found.
 Usage
 ```
-sage: proof.py [-h] --range RANGE_ARG [--cyclone-path CYCLONE_PATH] [--grid GRID_ARG] [--batch BATCH] [--timeout TIMEOUT] [--start-count START_COUNT] [--end-count END_COUNT] [--quartile-count QUARTILE_COUNT]
+usage: proof.py [-h] --range RANGE_ARG [--cyclone-path CYCLONE_PATH] [--grid GRID_ARG] [--batch BATCH] [--timeout TIMEOUT] [--start-count START_COUNT] [--end-count END_COUNT] [--quartile-count QUARTILE_COUNT]
 ```
 Sample start
 ```
@@ -92,6 +92,7 @@ Users have reported the following speeds:
 | RTX 4070 Ti Super | 512,1024  | 3170 Mkeys/s    | Community report       |
 | L4-2Q             | 512,256   | 1360 Mkeys/s    | Community report       |
 | RTX3070 mobile    | 256,256   | 1150 Mkeys/s    | Community report       |
+| RTX 3060          | 64,64     | 550 Mkeys/s     | Tested on Windows      |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,22 +184,35 @@ Time: 61.2 s | Speed: 1234.3 Mkeys/s | Count: 72707573152 | Progress: 52.90 %
 Private Key   : 00000000000000000000000000000000000000000000000000000022382FACD0
 Public Key    : 03C060E1E3771CBECCB38E119C2414702F3F5181A89652538851D2E3886BDD70C6
 ```
-## 🛠️ Getting Started
-To get started with CUDACyclone, clone the repository and type **make**  
-For totaly clean system (big thanks for **dev_nullish**):
+## 🛠️ Setup & Build
+
+### Linux
 ```bash
-apt update;
-apt-get install -y joe;
-apt-get install -y zip;
-apt-get install -y screen;
-apt-get install -y curl libcurl4;
-apt-get install build-essential;
-apt-get install -y gcc;
-apt-get install -y make;
-apt install cuda-toolkit;
-git clone https://github.com/Dookoo2/CUDACyclone.git
+# Clone e build automático (detecta CUDA, instala dependências, compila)
+git clone https://github.com/jmr2704/CUDACyclone.git
+cd CUDACyclone
+bash setup.sh
+```
+
+Ou manualmente (se já tiver CUDA e make instalados):
+```bash
 make
 ```
+
+### Windows
+```powershell
+# Clone e build automático (detecta CUDA, Visual Studio, make, compila)
+git clone https://github.com/jmr2704/CUDACyclone.git
+cd CUDACyclone
+.\setup.ps1
+```
+
+### Como funciona
+- O **Makefile** detecta automaticamente a compute capability da sua GPU e gera código otimizado para as arquiteturas 75, 86, 89 + a sua.
+- O **setup.sh** (Linux) instala CUDA Toolkit, build-essential e compila.
+- O **setup.ps1** (Windows) detecta CUDA Toolkit, Visual Studio, make e compila.
+- Ambos os scripts detectam a versão mais recente do CUDA disponível no sistema.
+- Rodando `make` direto (sem script) também funciona — usa `86` como fallback se não detectar a GPU.
 ## 🚧**Version**
 **V1.3**: Full CUDA Kernel rewrite again for preventing key skipping.    
 **V1.2**: Full CUDA Kernel rewrite.  
@@ -207,6 +220,14 @@ make
 **V1.0**: Release.
 
 
+
+---
+## 📜 Créditos
+
+Este repositório é um fork com modificações do [CUDACyclone original](https://github.com/Dookoo2/CUDACyclone) por **Dookoo2**.  
+Agradecimentos ao trabalho original que serviu como base para este projeto.
+
+---
 
 ## ✌️**TIPS**
 BTC: bc1qtq4y9l9ajeyxq05ynq09z8p52xdmk4hqky9c8n

--- a/README.md
+++ b/README.md
@@ -188,31 +188,31 @@ Public Key    : 03C060E1E3771CBECCB38E119C2414702F3F5181A89652538851D2E3886BDD70
 
 ### Linux
 ```bash
-# Clone e build automático (detecta CUDA, instala dependências, compila)
+# Automatic setup — detects CUDA, installs dependencies, builds
 git clone https://github.com/jmr2704/CUDACyclone.git
 cd CUDACyclone
 bash setup.sh
 ```
 
-Ou manualmente (se já tiver CUDA e make instalados):
+Or manually (if CUDA and build tools are already installed):
 ```bash
 make
 ```
 
 ### Windows
 ```powershell
-# Clone e build automático (detecta CUDA, Visual Studio, make, compila)
+# Automatic setup — detects CUDA Toolkit, Visual Studio, make, builds
 git clone https://github.com/jmr2704/CUDACyclone.git
 cd CUDACyclone
 .\setup.ps1
 ```
 
-### Como funciona
-- O **Makefile** detecta automaticamente a compute capability da sua GPU e gera código otimizado para as arquiteturas 75, 86, 89 + a sua.
-- O **setup.sh** (Linux) instala CUDA Toolkit, build-essential e compila.
-- O **setup.ps1** (Windows) detecta CUDA Toolkit, Visual Studio, make e compila.
-- Ambos os scripts detectam a versão mais recente do CUDA disponível no sistema.
-- Rodando `make` direto (sem script) também funciona — usa `86` como fallback se não detectar a GPU.
+### How it works
+- The **Makefile** automatically detects your GPU compute capability and generates optimized code for architectures 75, 86, 89 + yours.
+- **setup.sh** (Linux) installs CUDA Toolkit, build-essential and compiles.
+- **setup.ps1** (Windows) detects CUDA Toolkit, Visual Studio, make and compiles.
+- Both scripts detect the latest CUDA version available on your system.
+- Running `make` directly also works — falls back to `86` if no GPU is detected.
 ## 🚧**Version**
 **V1.3**: Full CUDA Kernel rewrite again for preventing key skipping.    
 **V1.2**: Full CUDA Kernel rewrite.  
@@ -222,10 +222,10 @@ cd CUDACyclone
 
 
 ---
-## 📜 Créditos
+## 📜 Credits
 
-Este repositório é um fork com modificações do [CUDACyclone original](https://github.com/Dookoo2/CUDACyclone) por **Dookoo2**.  
-Agradecimentos ao trabalho original que serviu como base para este projeto.
+This repository is a fork with modifications of the original [CUDACyclone](https://github.com/Dookoo2/CUDACyclone) by **Dookoo2**.  
+Thanks to the original work that served as the foundation for this project.
 
 ---
 

--- a/SESSAO.md
+++ b/SESSAO.md
@@ -1,3 +1,58 @@
+# 🐊 Sessão CUDACyclone — 2026-06-27
+
+## Contexto
+- **Projeto:** CUDACyclone — GPU Satoshi Puzzle Solver (CUDA)
+- **Repo:** `github.com/jmr2704/CUDACyclone`
+- **Branch:** `main`
+- **GPU alvo:** RTX 3060 (Compute 8.6)
+
+---
+
+## ✅ Tasks concluídas
+
+### 1. setup.ps1 testado no Windows real
+- Detecção de `GPU_ARCH` confirmada como **dinâmica** (`nvidia-smi` → `8.6` → `86`)
+- Build completo com CUDA 13.3 + VS2022 + make (Chocolatey)
+- Binário `CUDACyclone.exe` gerado e funcional
+
+### 2. Makefile bugfix — `del` no Windows
+- `RM := del /Q /F` → `RM := cmd /c del /Q /F`
+- `del` é comando interno do `cmd.exe`, não executável standalone → quebrava no `make clean`
+
+### 3. proof.py — compatibilidade Windows
+- `select.select()` substituído por `threading.Thread` (select só funciona com sockets no Windows)
+- `import select` removido
+- Script rodou 296/296 testes sem falhas ✅
+
+### 4. README atualizado
+- Typos corrigidos: `sage:` → `usage:`
+- RTX 3060 adicionado à tabela de benchmarks (550 Mkeys/s)
+
+### 5. Git push
+- Autenticação resolvida com token do `jmr2704`
+- Commit `b849825` enviado pro remote
+
+---
+
+## 📦 Commits
+
+| Hash | Descrição |
+|---|---|
+| `b849825` | Fix Windows compat: cmd /c del, select→threading, README typos |
+| `7d9712f` | Atualiza endereco BTC |
+| `80988ab` | README 100% ingles |
+| `152fefc` | Setup scripts, Makefile cross-platform, melhorias visuais |
+
+---
+
+## 🧭 Próximos passos
+
+1. **Tuning de performance** — testar `--grid` e `--slices` ideais pra RTX 3060
+2. **Teste de range maior** com `proof.py` (ex: `200000000:3FFFFFFFF`)
+3. **Documentar setup Windows** no README com prints do resultado
+
+---
+
 # 🐊 Sessão CUDACyclone — 2026-06-26
 
 ## Contexto

--- a/SESSAO.md
+++ b/SESSAO.md
@@ -1,0 +1,84 @@
+# 🐊 Sessão CUDACyclone — 2026-06-26
+
+## Contexto
+- **Projeto:** CUDACyclone — GPU Satoshi Puzzle Solver (CUDA)
+- **Repo:** `github.com/jmr2704/CUDACyclone`
+- **Branch:** `main`
+- **GPU alvo:** RTX 3060 (Compute 8.6) / Cross-platform
+
+---
+
+## ✅ Tasks concluídas
+
+### 1. Setup & Build cross-platform
+- `setup.sh` — Linux: detecta distro, instala CUDA, build-essential, builda
+- `setup.ps1` — Windows: detecta CUDA Toolkit, Visual Studio, make, builda
+- Ambos detectam `GPU_ARCH` automaticamente e passam pro Makefile
+
+### 2. Makefile cross-platform
+- `ifeq ($(OS),Windows_NT)` pra separar plataformas
+- `GPU_ARCH` detectado automaticamente:
+  - Linux: `nvidia-smi | head | tr`
+  - Windows: `powershell -Command "nvidia-smi | Select-Object -replace"`
+  - Fallback: `86`
+- Extensões: `.o` (Linux) / `.obj` (Windows)
+- Clean: `rm -f` (Linux) / `del /Q /F` (Windows)
+- Target: `CUDACyclone` (Linux) / `CUDACyclone.exe` (Windows)
+
+### 3. Melhorias visuais no `CUDACyclone.cu`
+- **Linha única de progresso:** `\r` + `std::setw()` com padding fixo
+- **Unidade automática de velocidade:**
+  - `< 1000` → `Mkeys/s`
+  - `>= 1000` → `Gkeys/s`
+  - `>= 1.000.000` → `Tkeys/s`
+
+### 4. README
+- Setup instructions pra Linux e Windows
+- Créditos ao repositório original (Dookoo2) no final
+- Carteira BTC atualizada
+
+### 5. Infra
+- `.gitignore` criado (`.o`, `.obj`, `.exe`, `CUDACyclone`)
+- Repositório criado em `jmr2704/CUDACyclone`
+
+---
+
+## 🔬 Testes realizados
+
+| Teste | Resultado |
+|---|---|
+| Build Linux (WSL Ubuntu 24.04, CUDA 12.0) | ✅ OK |
+| Execucao encontrou chave `0x22382FACD0` no range `2000000000:3FFFFFFFFF` | ✅ Encontrou em ~63s |
+| setup.ps1 parse (Windows PowerShell 5.1) | ✅ Parse OK |
+| setup.ps1 build real no Windows | ⚠️ Pendente (apos correcao `.obj`) |
+
+---
+
+## 🐛 Problemas conhecidos
+
+1. **Push no Windows:** git local autentica como `jeffmr2704`, precisa trocar pro `jmr2704`:
+   ```powershell
+   git remote set-url origin https://jmr2704:TOKEN@github.com/jmr2704/CUDACyclone.git
+   git push origin main
+   git remote set-url origin https://github.com/jmr2704/CUDACyclone.git
+   ```
+
+2. **setup.ps1 no Windows:** ultimo erro foi `cl.exe` rejeitando `.o` — corrigido com `OBJ_EXT := .obj` no Makefile, mas nao testado.
+
+---
+
+## 📦 Commits
+
+| Hash | Descrição |
+|---|---|
+| `7d9712f` | Atualiza endereco BTC |
+| `80988ab` | README 100% ingles |
+| `152fefc` | Setup scripts, Makefile cross-platform, melhorias visuais |
+
+---
+
+## ▶️ Proximos passos
+
+1. Testar `setup.ps1` no Windows com a correcao do `.obj`
+2. Resolver autenticacao git no Windows (ou usar `gh` CLI)
+3. Se tudo ok, considerar merge pra main (ja esta)

--- a/proof.py
+++ b/proof.py
@@ -7,7 +7,6 @@ import time
 import sys
 import math
 import random
-import select
 from typing import List, Tuple, Optional, Set, Dict
 from ecdsa import SECP256k1, SigningKey
 
@@ -107,14 +106,21 @@ def run_cyclone_and_watch(
         assert p.stdout is not None
         for line in p.stdout:
             if match_marker in line:
-                for _ in range(20):
-                    fd = p.stdout.fileno()
-                    rlist, _, _ = select.select([fd], [], [], 0.2)
-                    if not rlist:
-                        break
-                    nxt = p.stdout.readline()
-                    if not nxt:
-                        break
+                import threading
+                result_lines = []
+                def read_remaining():
+                    for _ in range(20):
+                        try:
+                            nxt = p.stdout.readline()
+                            if not nxt:
+                                break
+                            result_lines.append(nxt)
+                        except Exception:
+                            break
+                reader = threading.Thread(target=read_remaining, daemon=True)
+                reader.start()
+                reader.join(timeout=1.0)
+                for nxt in result_lines:
                     if "Private Key" in nxt:
                         parts = nxt.split(":", 1)
                         if len(parts) > 1:

--- a/setup.ps1
+++ b/setup.ps1
@@ -226,7 +226,7 @@ function Build-WithMake {
     $gpuArch = Get-GpuArch
     $env:GPU_ARCH = $gpuArch
     Write-Info "GPU_ARCH=$gpuArch (passado ao make)"
-    & make clean 2>$null
+    & make clean 2>&1 | Out-Null
     & make -j $env:NUMBER_OF_PROCESSORS
     if ($LASTEXITCODE -eq 0) {
         Write-Host ""

--- a/setup.ps1
+++ b/setup.ps1
@@ -153,10 +153,27 @@ function Find-Make {
         $resp = Read-Host
         if ($resp -eq 's' -or $resp -eq 'S') {
             Start-Process -FilePath "winget" -ArgumentList "install", "GnuWin32.Make", "--accept-package-agreements", "--accept-source-agreements" -Wait -PassThru -NoNewWindow | Out-Null
+            # PATH pode nao ter atualizado — varre locais comuns
+            $gnuPaths = @(
+                "${env:ProgramFiles}\GnuWin32\bin\make.exe",
+                "${env:ProgramFiles(x86)}\GnuWin32\bin\make.exe",
+                "${env:ProgramFiles}\make\bin\make.exe",
+                "${env:ProgramFiles(x86)}\make\bin\make.exe"
+            )
+            foreach ($gp in $gnuPaths) {
+                if (Test-Path $gp) {
+                    Write-Ok "make encontrado em: $gp"
+                    $env:Path = "$(Split-Path $gp);$env:Path"
+                    return $true
+                }
+            }
             if (Get-Command make.exe -ErrorAction SilentlyContinue) {
                 Write-Ok "make instalado"
                 return $true
             }
+            Write-Warn "make instalado, mas nao encontrado no PATH."
+            Write-Warn "Adicione manualmente ao PATH ou use: choco install make"
+            return $false
         }
     }
 
@@ -234,7 +251,8 @@ function Build-WithNvcc {
     # Prepara flags base
     $archFlags = Get-GpuArchFlags
     $commonFlags = @(
-        '-O3', '-rdc=true', '-use_fast_math', '--ptxas-options=-O3'
+        '-O3', '-rdc=true', '-use_fast_math', '--ptxas-options=-O3',
+        '-allow-unsupported-compiler'
     ) + $archFlags + @(
         '-std=c++17'
     )

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,329 @@
+﻿#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  CUDACyclone — Setup & Build (Windows)
+  Detecta dependencias (CUDA Toolkit, Visual Studio, make),
+  configura o ambiente e builda o projeto.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "+==========================================+" -ForegroundColor DarkCyan
+Write-Host "|     CUDACyclone - Setup & Build         |" -ForegroundColor DarkCyan
+Write-Host "+==========================================+" -ForegroundColor DarkCyan
+
+function Write-Info   { Write-Host "[INFO]  $args" -ForegroundColor Cyan }
+function Write-Ok     { Write-Host "[OK]    $args" -ForegroundColor Green }
+function Write-Warn   { Write-Host "[WARN]  $args" -ForegroundColor Yellow }
+function Write-Err    { Write-Host "[ERROR] $args" -ForegroundColor Red }
+
+# ── 1. CUDA Toolkit ───────────────────────────
+function Find-CudaToolkit {
+    # Tenta via PATH primeiro
+    $nvccCmd = Get-Command nvcc.exe -ErrorAction SilentlyContinue
+    if ($nvccCmd) {
+        Write-Ok "nvcc encontrado no PATH"
+        $ver = & nvcc.exe --version 2>&1 | Select-String "release"
+        if ($ver) {
+            if ($ver -match 'release (\S+)') {
+                Write-Ok "CUDA Toolkit v$($Matches[1])"
+            }
+        }
+        return $true
+    }
+
+    # Varre diretorios do CUDA Toolkit
+    $base = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
+    if (Test-Path $base) {
+        $cudaDirs = Get-ChildItem -Path "$base\v*" -Directory | Sort-Object Name -Descending
+        if ($cudaDirs.Count -gt 0) {
+            $latest = $cudaDirs[0].FullName
+            Write-Warn "CUDA encontrado em $latest — adicionando ao PATH..."
+            $env:Path = "$latest\bin;$latest\libnvvp;$env:Path"
+            if (Get-Command nvcc.exe -ErrorAction SilentlyContinue) {
+                $ver = & nvcc.exe --version 2>&1 | Select-String "release"
+                if ($ver -and $ver -match 'release (\S+)') {
+                    Write-Ok "CUDA Toolkit v$($Matches[1]) configurado"
+                }
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+function Install-CudaToolkitWindows {
+    Write-Warn "CUDA Toolkit nao encontrado!"
+    Write-Warn "Baixe e instale manualmente de:"
+    Write-Warn "  https://developer.nvidia.com/cuda-downloads"
+    Write-Host ""
+    Write-Host "  Tentar instalar via winget? (s/N) " -ForegroundColor Cyan -NoNewline
+    $resp = Read-Host
+    if ($resp -eq 's' -or $resp -eq 'S') {
+        try {
+            $proc = Start-Process -FilePath "winget" -ArgumentList "install", "NVIDIA.CUDA", "--accept-package-agreements", "--accept-source-agreements" -Wait -PassThru -NoNewWindow
+            if ($proc.ExitCode -eq 0) {
+                return (Find-CudaToolkit)
+            }
+        } catch {
+            Write-Err "Falha: $_"
+        }
+    }
+    return $false
+}
+
+# ── 2. Visual Studio ──────────────────────────
+function Find-VisualStudio {
+    $vsPaths = @(
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+    )
+
+    foreach ($p in $vsPaths) {
+        if (Test-Path $p) {
+            Write-Ok "Visual Studio: $p"
+            return $p
+        }
+    }
+
+    # vswhere
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $vsPath = & $vswhere -latest -property installationPath 2>$null
+        if ($vsPath) {
+            $vcvars = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+            if (Test-Path $vcvars) {
+                Write-Ok "Visual Studio via vswhere: $vcvars"
+                return $vcvars
+            }
+        }
+    }
+
+    # cl.exe ja no PATH?
+    if (Get-Command cl.exe -ErrorAction SilentlyContinue) {
+        Write-Ok "cl.exe encontrado no PATH"
+        return $null
+    }
+
+    Write-Warn "Visual Studio / Build Tools nao encontrados."
+    Write-Warn "O nvcc precisa do compilador host (cl.exe)."
+    Write-Warn "Veja: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022"
+    Write-Warn "Selecione a workload 'Desktop development with C++'."
+    return $null
+}
+
+# ── 3. make ───────────────────────────────────
+function Find-Make {
+    if (Get-Command make.exe -ErrorAction SilentlyContinue) {
+        Write-Ok "make encontrado: $(Get-Command make.exe).Source"
+        return $true
+    }
+
+    # Procura no PATH expandido
+    foreach ($p in $env:Path.Split(';')) {
+        $test = Join-Path -Path $p -ChildPath "make.exe"
+        if (Test-Path $test) {
+            Write-Ok "make encontrado em: $test"
+            return $true
+        }
+    }
+
+    # Chocolatey
+    if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+        Write-Warn "Instalar make via Chocolatey? (s/N) " -NoNewline
+        $resp = Read-Host
+        if ($resp -eq 's' -or $resp -eq 'S') {
+            Start-Process -FilePath "choco" -ArgumentList "install", "make", "-y" -Wait -PassThru -NoNewWindow | Out-Null
+            if (Get-Command make.exe -ErrorAction SilentlyContinue) {
+                Write-Ok "make instalado"
+                return $true
+            }
+        }
+    }
+
+    # winget
+    if (Get-Command winget.exe -ErrorAction SilentlyContinue) {
+        Write-Warn "Instalar make via winget? (s/N) " -NoNewline
+        $resp = Read-Host
+        if ($resp -eq 's' -or $resp -eq 'S') {
+            Start-Process -FilePath "winget" -ArgumentList "install", "GnuWin32.Make", "--accept-package-agreements", "--accept-source-agreements" -Wait -PassThru -NoNewWindow | Out-Null
+            if (Get-Command make.exe -ErrorAction SilentlyContinue) {
+                Write-Ok "make instalado"
+                return $true
+            }
+        }
+    }
+
+    Write-Warn "make nao encontrado. Instale manualmente: choco install make"
+    return $false
+}
+
+# ── 4. nvidia-smi ─────────────────────────────
+function Find-NvidiaSmi {
+    if (Get-Command nvidia-smi.exe -ErrorAction SilentlyContinue) {
+        $info = & nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader 2>&1
+        if ($info) {
+            Write-Ok "GPU: $info"
+            return $true
+        }
+    }
+    Write-Warn "nvidia-smi nao encontrado (drivers NVIDIA podem nao estar instalados)"
+    return $false
+}
+
+# ── Detecta compute capability ────────────────
+function Get-GpuArch {
+    $info = & nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>$null
+    if ($info) {
+        $cc = $info.Trim() -replace '\.', ''
+        if ($cc) { return $cc }
+    }
+    # Fallback: tenta via nvcc
+    $nvccPath = (Get-Command nvcc.exe -ErrorAction SilentlyContinue).Source
+    if (-not $nvccPath) { return "86" }  # fallback generico
+    return "86"
+}
+
+function Get-GpuArchFlags {
+    $cc = Get-GpuArch
+    $archs = @(75, 86, 89, [int]$cc) | Sort-Object -Unique
+    $flags = @()
+    foreach ($a in $archs) {
+        $flags += "-gencode", "arch=compute_${a},code=sm_${a}"
+    }
+    Write-Info "Arquiteturas GPU alvo: $($archs -join ', ')"
+    return $flags
+}
+
+# ── Build com make ────────────────────────────
+function Build-WithMake {
+    Write-Info "Buildando com make..."
+    & make clean 2>$null
+    # Passa GPU_ARCH pra evitar que o make chame nvidia-smi no cmd.exe
+    $gpuArch = Get-GpuArch
+    $env:GPU_ARCH = $gpuArch
+    Write-Info "GPU_ARCH=$gpuArch (passado ao make)"
+    & make -j $env:NUMBER_OF_PROCESSORS
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host ""
+        Write-Host "+==========================================+" -ForegroundColor Green
+        Write-Host         "|    BUILD CONCLUIDO COM SUCESSO!         |" -ForegroundColor Green
+        Write-Host "+==========================================+" -ForegroundColor Green
+        Write-Host ""
+        $bin = Get-ChildItem "CUDACyclone.exe" -ErrorAction SilentlyContinue
+        if ($bin) { Write-Host "  Binario: $($bin.FullName)" }
+        Write-Host ""
+        Write-Host "  Para executar:"
+        Write-Host "    .\CUDACyclone.exe --range INICIO:FIM --address ENDERECO"
+        Write-Host ""
+        return $true
+    }
+    return $false
+}
+
+# ── Build direto com nvcc ─────────────────────
+function Build-WithNvcc {
+    Write-Warn "make nao disponivel. Compilando direto com nvcc..."
+
+    # Prepara flags base
+    $archFlags = Get-GpuArchFlags
+    $commonFlags = @(
+        '-O3', '-rdc=true', '-use_fast_math', '--ptxas-options=-O3'
+    ) + $archFlags + @(
+        '-std=c++17'
+    )
+    $linkFlags = @('-lcudadevrt', '-cudart=static')
+
+    $srcs = @('CUDACyclone.cu', 'CUDAHash.cu')
+    $objs = @()
+
+    foreach ($s in $srcs) {
+        $obj = $s -replace '\.cu$', '.o'
+        Write-Info "Compilando $s -> $obj ..."
+        & nvcc -c $commonFlags $s -o $obj
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err "Falha ao compilar $s"
+            return $false
+        }
+        $objs += $obj
+    }
+
+    Write-Info "Linkando..."
+    & nvcc $commonFlags $objs -o "CUDACyclone.exe" $linkFlags
+    if ($LASTEXITCODE -eq 0) {
+        Write-Ok "Build concluido! Binario: CUDACyclone.exe"
+        return $true
+    } else {
+        Write-Err "Falha no link. Verifique se o Visual Studio esta configurado corretamente."
+        return $false
+    }
+}
+
+# ── Main ───────────────────────────────────────
+function Main {
+    Write-Host ""
+
+    # 1. CUDA
+    Write-Info "Verificando CUDA Toolkit..."
+    if (-not (Find-CudaToolkit)) {
+        if (-not (Install-CudaToolkitWindows)) {
+            Write-Err "CUDA Toolkit e obrigatorio. Abortando."
+            exit 1
+        }
+    }
+
+    # 2. Visual Studio
+    Write-Info "Verificando Visual Studio..."
+    $vcvars = Find-VisualStudio
+    if ($vcvars) {
+        Write-Info "Configurando ambiente via: $vcvars"
+        # Executa vcvars64.bat e captura variaveis de ambiente
+        $output = & cmd /c "call `"$vcvars`" > nul 2>&1 && set" 2>&1
+        foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)') {
+                $varName = $Matches[1]
+                $varValue = $Matches[2]
+                Set-Item -Path "env:$varName" -Value $varValue -ErrorAction SilentlyContinue
+            }
+        }
+        Write-Ok "Ambiente Visual Studio configurado"
+    }
+
+    # 3. make
+    Write-Info "Verificando make..."
+    $hasMake = Find-Make
+
+    # 4. GPU
+    Write-Info "Verificando GPU NVIDIA..."
+    Find-NvidiaSmi | Out-Null
+
+    # 5. Build
+    Write-Host ""
+    Write-Info "Iniciando build..."
+    Write-Host ""
+
+    if (Test-Path "Makefile") {
+        if ($hasMake) {
+            if (-not (Build-WithMake)) {
+                Write-Err "Build com make falhou."
+                exit 1
+            }
+        } else {
+            if (-not (Build-WithNvcc)) {
+                Write-Err "Build com nvcc falhou."
+                exit 1
+            }
+        }
+    } else {
+        Write-Err "Makefile nao encontrado."
+        exit 1
+    }
+}
+
+Main

--- a/setup.ps1
+++ b/setup.ps1
@@ -221,11 +221,12 @@ function Get-GpuArchFlags {
 # ── Build com make ────────────────────────────
 function Build-WithMake {
     Write-Info "Buildando com make..."
-    & make clean 2>$null
-    # Passa GPU_ARCH pra evitar que o make chame nvidia-smi no cmd.exe
+    # Detecta GPU_ARCH antes de qualquer chamada ao make
+    # pra evitar que o Makefile tente rodar nvidia-smi via cmd.exe
     $gpuArch = Get-GpuArch
     $env:GPU_ARCH = $gpuArch
     Write-Info "GPU_ARCH=$gpuArch (passado ao make)"
+    & make clean 2>$null
     & make -j $env:NUMBER_OF_PROCESSORS
     if ($LASTEXITCODE -eq 0) {
         Write-Host ""

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────
+#  CUDACyclone — Setup & Build (Linux)
+#  Detecta dependências, instala o que faltar,
+#  e builda o projeto automaticamente.
+# ──────────────────────────────────────────────
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+err()   { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# ── Detect distro ─────────────────────────────
+detect_distro() {
+    if   [ -f /etc/os-release ]; then . /etc/os-release; echo "$ID"
+    elif [ -f /etc/debian_version ]; then echo "debian"
+    elif [ -f /etc/redhat-release ]; then echo "rhel"
+    elif command -v pacman &>/dev/null; then echo "arch"
+    else echo "unknown"; fi
+}
+
+DISTRO=$(detect_distro)
+info "Distro detectada: ${DISTRO}"
+
+# ── Verifica / instala CUDA toolkit ────────────
+check_cuda() {
+    if command -v nvcc &>/dev/null; then
+        CUDA_VER=$(nvcc --version | grep "release" | sed -E 's/.*release ([0-9]+\.[0-9]+).*/\1/')
+        ok "CUDA Toolkit ${CUDA_VER} encontrado em $(which nvcc)"
+        return 0
+    fi
+    return 1
+}
+
+install_cuda_debian() {
+    warn "CUDA Toolkit não encontrado. Instalando via NVIDIA package manager..."
+    # Pega a versão do Ubuntu/Debian
+    UBUNTU_VER=$(lsb_release -rs 2>/dev/null || echo "22.04")
+    # Monta a URL do repositório NVIDIA
+    local distro_arch="x86_64"
+    local os_name="ubuntu$(echo "$UBUNTU_VER" | tr -d '.')"
+    
+    info "Baixando CUDA keyring..."
+    wget -q "https://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}${UBUNTU_VER}/${distro_arch}/cuda-keyring_1.1-1_all.deb" -O /tmp/cuda-keyring.deb 2>/dev/null || {
+        # Fallback: método alternativo
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nvidia-cuda-toolkit 2>&1 | tail -5
+        if command -v nvcc &>/dev/null; then
+            ok "CUDA instalado via apt (nvidia-cuda-toolkit)"
+            return 0
+        fi
+        err "Falha ao instalar CUDA. Instale manualmente:"
+        err "  https://developer.nvidia.com/cuda-downloads"
+        return 1
+    }
+    dpkg -i /tmp/cuda-keyring.deb && apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cuda-toolkit 2>&1 | tail -5
+    rm -f /tmp/cuda-keyring.deb
+}
+
+install_cuda_rhel() {
+    warn "CUDA Toolkit não encontrado. Instalando..."
+    if command -v dnf &>/dev/null; then
+        dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel$(rpm -E %rhel)/x86_64/cuda-rhel$(rpm -E %rhel).repo
+        dnf install -y cuda-toolkit 2>&1 | tail -5
+    else
+        yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel$(rpm -E %rhel)/x86_64/cuda-rhel$(rpm -E %rhel).repo
+        yum install -y cuda-toolkit 2>&1 | tail -5
+    fi
+}
+
+install_cuda_arch() {
+    warn "CUDA Toolkit não encontrado. Instalando via pacman..."
+    pacman -Sy --noconfirm cuda 2>&1 | tail -5
+}
+
+install_cuda_auto() {
+    case "$DISTRO" in
+        debian|ubuntu) install_cuda_debian ;;
+        rhel|fedora|centos) install_cuda_rhel ;;
+        arch) install_cuda_arch ;;
+        *)
+            err "Distro '$DISTRO' não suportada para instalação automática."
+            err "Instale o CUDA Toolkit manualmente: https://developer.nvidia.com/cuda-downloads"
+            return 1
+            ;;
+    esac
+}
+
+# ── Verifica / instala build tools ────────────
+check_build_tools() {
+    local missing=0
+    for cmd in make g++; do
+        if ! command -v "$cmd" &>/dev/null; then
+            warn "$cmd não encontrado."
+            missing=1
+        fi
+    done
+    if [ "$missing" -eq 0 ]; then
+        ok "Build tools (make, g++) disponíveis"
+        return 0
+    fi
+    return 1
+}
+
+install_build_tools() {
+    warn "Instalando build tools..."
+    case "$DISTRO" in
+        debian|ubuntu)     apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential 2>&1 | tail -3 ;;
+        rhel|fedora|centos) dnf install -y gcc-c++ make 2>&1 | tail -3 || yum install -y gcc-c++ make 2>&1 | tail -3 ;;
+        arch)              pacman -Sy --noconfirm base-devel 2>&1 | tail -3 ;;
+        *)                 err "Não foi possível instalar build tools automaticamente."; return 1 ;;
+    esac
+}
+
+# ── Adiciona CUDA ao PATH se necessário ────────
+ensure_cuda_in_path() {
+    # Tenta achar nvcc em lugares comuns
+    if ! command -v nvcc &>/dev/null; then
+        for dir in /usr/local/cuda-*/bin /opt/cuda/bin /usr/lib/cuda/bin; do
+            if [ -f "$dir/nvcc" ]; then
+                export PATH="$dir:$PATH"
+                ok "CUDA encontrado em $dir (adicionado ao PATH)"
+                break
+            fi
+        done
+        # Fallback: /usr/local/cuda (symlink mais recente)
+        if ! command -v nvcc &>/dev/null && [ -f /usr/local/cuda/bin/nvcc ]; then
+            export PATH="/usr/local/cuda/bin:$PATH"
+            ok "CUDA encontrado em /usr/local/cuda/bin"
+        fi
+    fi
+    
+    # Biblioteca CUDA pro linker
+    if [ -d /usr/local/cuda/lib64 ]; then
+        export LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
+    fi
+    
+    if ! command -v nvcc &>/dev/null; then
+        err "nvcc não encontrado. CUDA Toolkit não está instalado."
+        return 1
+    fi
+}
+
+# ── Main ───────────────────────────────────────
+main() {
+    echo ""
+    echo -e "${CYAN}╔══════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║     CUDACyclone — Setup & Build         ║${NC}"
+    echo -e "${CYAN}╚══════════════════════════════════════════╝${NC}"
+    echo ""
+    
+    # 1. CUDA Toolkit
+    info "Verificando CUDA Toolkit..."
+    if ! check_cuda; then
+        ensure_cuda_in_path || install_cuda_auto || { err "CUDA é obrigatório. Abortando."; exit 1; }
+        check_cuda || { err "CUDA ainda não detectado após instalação. Abortando."; exit 1; }
+    fi
+    
+    # 2. Build tools
+    info "Verificando build tools..."
+    check_build_tools || { install_build_tools; check_build_tools || { err "Build tools não disponíveis. Abortando."; exit 1; } }
+    
+    # 3. GPU / driver
+    info "Verificando GPU NVIDIA..."
+    GPU_ARCH="86"  # fallback padrão
+    if command -v nvidia-smi &>/dev/null; then
+        GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)
+        GPU_CC=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1)
+        GPU_ARCH=$(echo "$GPU_CC" | tr -d '.')
+        ok "GPU: ${GPU_NAME} (Compute ${GPU_CC})"
+    else
+        warn "nvidia-smi não encontrado. Drivers NVIDIA podem não estar instalados."
+        warn "O binário será compilado mas pode não executar sem GPU NVIDIA + driver."
+    fi
+    export GPU_ARCH
+    ok "GPU_ARCH=${GPU_ARCH} (passado ao make)"
+    
+    # 4. Build!
+    echo ""
+    info "Buildando o projeto..."
+    make clean 2>/dev/null || true
+    if make -j$(nproc); then
+        echo ""
+        echo -e "${GREEN}╔══════════════════════════════════════════╗${NC}"
+        echo -e "${GREEN}║  ✅  BUILD CONCLUÍDO COM SUCESSO!       ║${NC}"
+        echo -e "${GREEN}╚══════════════════════════════════════════╝${NC}"
+        echo ""
+        echo -e "  Binário: ${CYAN}$(pwd)/CUDACyclone${NC}"
+        echo -e "  Tamanho: $(ls -lh CUDACyclone | awk '{print $5}')"
+        echo ""
+        echo -e "  Para executar:"
+        echo -e "    ${YELLOW}./CUDACyclone --range INICIO:FIM --address ENDERECO${NC}"
+        echo ""
+    else
+        err "Build falhou!"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **Multi-GPU**: the searcher now automatically detects all CUDA GPUs and spawns one worker thread per GPU. Each thread calls `cudaSetDevice()` and manages its own CUDA context (streams, constant memory, EC point buffers). An atomic `GpuShared` struct coordinates the found-flag, hash count, and result across threads.

- **Fast cross-GPU stop**: when GPU A finds the key it sets `shared.any_found`. GPU B detects this in its polling loop and immediately writes `FOUND_READY` to its own `d_found_flag`, causing the running kernel to exit at the next `warp_found_ready` check — no waiting for the full kernel to finish.

- **Race condition fix**: `d_found_flag` is re-read after `cudaStreamSynchronize` to catch the race where `cudaStreamQuery` returns success before the polling loop reads `FOUND_READY`.

- **Makefile — all GPU architectures**: detects compute capability of every installed GPU (not just the first) and compiles a cubin for each. Heterogeneous setups like RTX 3060 (sm_86) + GTX 1070 (sm_61) work without manual flags.

- **`--random` flag — lottery/random-jump mode**: instead of scanning linearly, each GPU independently picks a random position within the full range before every kernel launch, re-initialises EC starting points via `scalarMulKernelBase`, then searches that chunk. Both GPUs cover the entire range independently. Use `--slices N` to tune chunk size vs. jump frequency.

## Usage

```bash
# Sequential scan (2 GPUs, range split evenly)
./CUDACyclone --range START:END --address ADDR --grid 512,256

# Random/lottery mode (both GPUs jump randomly across full range)
./CUDACyclone --range START:END --address ADDR --grid 512,256 --random --slices 8
```

## Test environment

- GPU 0: NVIDIA GeForce RTX 3060 (sm_86, 28 SMs, 12 GB)
- GPU 1: NVIDIA GeForce GTX 1070 (sm_61, 15 SMs, 8 GB)
- Combined speed: ~1.4 Gkeys/s
- Both modes tested and verified finding known keys.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)